### PR TITLE
Avoid use internal core header file use Arduino.h instead

### DIFF
--- a/src/STM32FreeRTOS.c
+++ b/src/STM32FreeRTOS.c
@@ -11,7 +11,7 @@
  * \param[in] millis milliseconds to delay
  */
 static void delayMS(uint32_t millis) {
-  uint32_t iterations = millis * (SystemCoreClock/7000);
+  uint32_t iterations = millis * (F_CPU/7000);
   uint32_t i;
   for(i = 0; i < iterations; ++i) {
     __asm__("nop\n\t");

--- a/src/port.c
+++ b/src/port.c
@@ -3,7 +3,7 @@
  * @author  Frederic Pillon <frederic.pillon@st.com> for STMicroelectronics.
  * @brief   Include source of FreeRTOS portable layer file to match Arduino library format
  */
-#include "stm32_def.h"
+#include <Arduino.h>
 
 #ifndef __CORTEX_M
 #pragma GCC error  "no \"__CORTEX_M\" definition"

--- a/src/portmacro.h
+++ b/src/portmacro.h
@@ -6,7 +6,7 @@
 
 #ifndef _PORTMACRO_H_
 #define _PORTMACRO_H_
-#include "stm32_def.h"
+#include <Arduino.h>
 
 #ifndef __CORTEX_M
 #pragma GCC error  "no \"__CORTEX_M\" definition"


### PR DESCRIPTION
Up to the used core to define properly what the library need.
Mainly the _cortex M_ core to use:
Ex: for **STM32F103** based board:
`#define __CORTEX_M (0x03U) /*!< Cortex-M Core */`

https://github.com/stm32duino/Arduino_Core_STM32 uses the CMSIS which defined it.
https://github.com/ARM-software/CMSIS/blob/6891719834ac6ca2a79e8ded00620faffae10ae8/CMSIS/Include/core_cm3.h#L79

Fix #3
