### PR TITLE
Library v9.0.4 manifest with disabled archiving for @PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,15 @@
+{
+    "name": "STM32duino FreeRTOS",
+    "version": "9.0.4",
+    "keywords": "rtos, timing, thread, task, mutex, semaphore",
+    "description": "Real Time Operating System implemented for STM32",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/stm32duino/STM32FreeRTOS.git"
+    },
+    "frameworks": "arduino",
+    "platforms": "ststm32",
+    "build": {
+        "libArchive": false
+    }
+}


### PR DESCRIPTION
Resolves:
- https://github.com/stm32duino/STM32FreeRTOS/issues/17
- https://github.com/platformio/platform-ststm32/issues/237