### PR TITLE
Add ltorg to gcc arm cm3+4f+7 port 

### DIFF
--- a/portable/GCC/ARM_CM3/port.c
+++ b/portable/GCC/ARM_CM3/port.c
@@ -247,6 +247,7 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg 				\n" /* make sure the pool is placed here, so ldr doesn't generate a too long jump */
 				);
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM4F/port.c
+++ b/portable/GCC/ARM_CM4F/port.c
@@ -277,6 +277,7 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg 				\n" /* make sure the pool is placed here, so ldr doesn't generate a too long jump */
 				);
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM4F/port.c
+++ b/portable/GCC/ARM_CM4F/port.c
@@ -707,7 +707,8 @@ static void vPortEnableVFP( void )
 		"								\n"
 		"	orr r1, r1, #( 0xf << 20 )	\n" /* Enable CP10 and CP11 coprocessors, then save back. */
 		"	str r1, [r0]				\n"
-		"	bx r14						"
+		"	bx r14						\n"
+		"   .ltorg 						\n" /* make sure the pool is placed here, so ldr doesn't generate a too long jump */		
 	);
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM7/r0p1/port.c
+++ b/portable/GCC/ARM_CM7/r0p1/port.c
@@ -271,6 +271,7 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg 				\n" /* make sure the pool is placed here, so ldr doesn't generate a too long jump */
 				);
 }
 /*-----------------------------------------------------------*/
@@ -697,7 +698,8 @@ static void vPortEnableVFP( void )
 		"								\n"
 		"	orr r1, r1, #( 0xf << 20 )	\n" /* Enable CP10 and CP11 coprocessors, then save back. */
 		"	str r1, [r0]				\n"
-		"	bx r14						"
+		"	bx r14						\n"
+		"   .ltorg 						\n" /* make sure the pool is placed here, so ldr doesn't generate a too long jump */
 	);
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Add LTORG to prvPortStartFirstTask and vPortEnableVFP to enable compile with GCC and LTO optimization.

https://bugs.launchpad.net/gcc-arm-embedded/+bug/1763050

fixes #27 