### PR TITLE
Update library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "STM32duino FreeRTOS",
-    "version": "10.0.1",
+    "version": "10.0.2",
     "keywords": "rtos, timing, thread, task, mutex, semaphore",
     "description": "Real Time Operating System implemented for STM32",
     "repository": {


### PR DESCRIPTION
The `library.properties` was correctly updated

https://github.com/stm32duino/STM32FreeRTOS/blob/bb0efc70fef1e6da3b0f73ea5a3429b3f23ce857/library.properties#L2

but the `library.json` is missing the version increase.