### PR TITLE
Update to Freertos 10.3.1 Add CortexM33 support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ CMSIS-RTOSv2.
 
 * MPU: not supported.
 * No CMSIS-RTOSv2 support provided. It is provided as example.
+* On Cortex-M0 and Cortex-M0+, all IT are disabled between xTaskCreate() and vTaskStartScheduler().
+  So it is not possible to use IT inbetween, like Serial.print() ...
+  This is the reason why, in example "frLiyLayland", between xTaskCreate() and vTaskStartScheduler(),
+  we use direct printf(), which will access directly USART without interrupt
 
 ## Files & Configuration
 
@@ -109,8 +113,8 @@ CMSIS-RTOSv2.
 ### STM32FreeRTOS v10.3.1
 | Board | AnalogRead_DigitalRead | frBlinkPrint | frLiuLayland | frBlink (CMSIS-RTOSv2) | Blinky (CMSIS-RTOSv2) |
 | --- | :---: | :---: | :---: | :---: | :---: |
-| [Nucleo F091RC (Cortex-M0)](http://www.st.com/en/evaluation-tools/nucleo-f091rc.html) | PASSED | PASSED | FAILED | PASSED | PASSED |
-| [Nucleo G071RB (Cortex-M0+)](http://www.st.com/en/evaluation-tools/nucleo-g071rb.html) | PASSED | PASSED | FAILED | PASSED | PASSED |
+| [Nucleo F091RC (Cortex-M0)](http://www.st.com/en/evaluation-tools/nucleo-f091rc.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
+| [Nucleo G071RB (Cortex-M0+)](http://www.st.com/en/evaluation-tools/nucleo-g071rb.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
 | [Nucleo F103RB (Cortex-M3)](http://www.st.com/en/evaluation-tools/nucleo-f103rb.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
 | [Nucleo L476RG (Cortex-M4)](http://www.st.com/en/evaluation-tools/nucleo-l476rg.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
 | [Nucleo H743ZI (Cortex-M7)](https://www.st.com/en/evaluation-tools/nucleo-h743zi.html) | PASSED | PASSED | PASSED | PASSED | PASSED |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ CMSIS-RTOSv2.
 | --- | :---: | :---: | :---: | :---: | :---: |
 | [Nucleo F091RC (Cortex-M0)](http://www.st.com/en/evaluation-tools/nucleo-f091rc.html) | PASSED | PASSED | FAILED | PASSED | PASSED |
 | [Nucleo G071RB (Cortex-M0+)](http://www.st.com/en/evaluation-tools/nucleo-g071rb.html) | PASSED | PASSED | FAILED | PASSED | PASSED |
-| [Nucleo L476RG (Cortex-M3)](http://www.st.com/en/evaluation-tools/nucleo-l476rg.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
+| [Nucleo F103RB (Cortex-M3)](http://www.st.com/en/evaluation-tools/nucleo-f103rb.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
 | [Nucleo L476RG (Cortex-M4)](http://www.st.com/en/evaluation-tools/nucleo-l476rg.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
 | [Nucleo H743ZI (Cortex-M7)](https://www.st.com/en/evaluation-tools/nucleo-h743zi.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
+| [Nucleo L552ZE-Q (Cortex-M33)](https://www.st.com/en/evaluation-tools/nucleo-l552ze-q.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
+| [Nucleo U575ZI-Q (Cortex-M33)](https://www.st.com/en/evaluation-tools/nucleo-u575zi-q.html) | PASSED | PASSED | PASSED | PASSED | PASSED |

--- a/README.md
+++ b/README.md
@@ -105,3 +105,12 @@ CMSIS-RTOSv2.
 | [P-Nucleo-WB55RG](https://www.st.com/en/evaluation-tools/p-nucleo-wb55.html) | PASSED | PASSED | FAILED | PASSED | PASSED |
 
 \* PASSED with `configUSE_NEWLIB_REENTRANT` set to 0 due to small RAM.
+
+### STM32FreeRTOS v10.3.1
+| Board | AnalogRead_DigitalRead | frBlinkPrint | frLiuLayland | frBlink (CMSIS-RTOSv2) | Blinky (CMSIS-RTOSv2) |
+| --- | :---: | :---: | :---: | :---: | :---: |
+| [Nucleo F091RC (Cortex-M0)](http://www.st.com/en/evaluation-tools/nucleo-f091rc.html) | PASSED | PASSED | FAILED | PASSED | PASSED |
+| [Nucleo G071RB (Cortex-M0+)](http://www.st.com/en/evaluation-tools/nucleo-g071rb.html) | PASSED | PASSED | FAILED | PASSED | PASSED |
+| [Nucleo L476RG (Cortex-M3)](http://www.st.com/en/evaluation-tools/nucleo-l476rg.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
+| [Nucleo L476RG (Cortex-M4)](http://www.st.com/en/evaluation-tools/nucleo-l476rg.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
+| [Nucleo H743ZI (Cortex-M7)](https://www.st.com/en/evaluation-tools/nucleo-h743zi.html) | PASSED | PASSED | PASSED | PASSED | PASSED |

--- a/examples/frLiuLayland/frLiuLayland.ino
+++ b/examples/frLiuLayland/frLiuLayland.ino
@@ -64,7 +64,7 @@ void calibrate() {
   uint32_t t = micros();
   burnCPU(1000);
   t = micros() - t;
-  cal = (TICK_USEC*1000*cal)/t;
+  cal = (TICK_USEC * 1000 * cal) / t;
 }
 //------------------------------------------------------------------------------
 // print helpers
@@ -85,7 +85,7 @@ void done(const char* msg, task_t* task, TickType_t now) {
   Serial.print("Task: ");
   Serial.flush();
   printTask(task);
-  while(1);
+  while (1);
 }
 //------------------------------------------------------------------------------
 // start tasks at 1000 ticks
@@ -123,7 +123,7 @@ void setup() {
   portBASE_TYPE s;  // task create status
 
   Serial.begin(9600);
-  while(!Serial) {}
+  while (!Serial) {}
   Serial.println("Rate Monotonic Scheduling Examples.");
   Serial.println("Cases 1 and 3 should fail");
   Serial.println("Cases 2 and 4 should succeed");
@@ -152,18 +152,18 @@ void setup() {
 
   uint32_t t = micros();
   burnCPU(1000);
-  Serial.println(micros() -t);
+  Serial.println(micros() - t);
   Serial.println("Starting tasks - period and CPU in ticks");
   Serial.println("Period,CPU,Priority");
   Serial.flush();
   for (int i = 0; i < n; i++) {
     printTask(&tasks[i]);
-    cpuUse += tasks[i].cpu/(float)tasks[i].period;
+    cpuUse += tasks[i].cpu / (float)tasks[i].period;
 
     s = xTaskCreate(task, NULL, 200, (void*)&tasks[i], tasks[i].priority, NULL);
     if (s != pdPASS) {
       printf("task create failed\n");
-      while(1);
+      while (1);
     }
   }
 
@@ -174,7 +174,7 @@ void setup() {
   // start tasks
   vTaskStartScheduler();
   Serial.println("Scheduler failed");
-  while(1);
+  while (1);
 }
 //------------------------------------------------------------------------------
 // WARNING idle loop has a very small stack (configMINIMAL_STACK_SIZE)

--- a/portable/CMSIS_RTOS_V2/cmsis_os2.c
+++ b/portable/CMSIS_RTOS_V2/cmsis_os2.c
@@ -156,8 +156,8 @@ extern void xPortSysTickHandler (void);
   SysTick handler implementation that also clears overflow flag.
 */
 /* SysTick handler implementation done in the core and call osSystickHandler */
-#if !defined(ARDUINO_ARCH_STM32) && (USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION == 0)
-void SysTick_Handler (void) {
+#if (USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION == 0)
+void osSystickHandler (void) {
   /* Clear overflow flag */
   SysTick->CTRL;
 
@@ -166,7 +166,7 @@ void SysTick_Handler (void) {
     xPortSysTickHandler();
   }
 }
-#endif /* !ARDUINO_ARCH_STM32 && (USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION == 0)*/
+#endif /* USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION == 0*/
 #endif /* SysTick */
 
 /*

--- a/portable/CMSIS_RTOS_V2/cmsis_os2.c
+++ b/portable/CMSIS_RTOS_V2/cmsis_os2.c
@@ -1,6 +1,5 @@
 /* --------------------------------------------------------------------------
- * Portions Copyright © 2019 STMicroelectronics International N.V. All rights reserved.
- * Copyright (c) 2013-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,12 +23,15 @@
 #include <string.h>
 
 #include "cmsis_os2.h"                  // ::CMSIS:RTOS2
-#include "cmsis_compiler.h"
+#include "cmsis_compiler.h"             // Compiler agnostic definitions
 
 #include "FreeRTOS.h"                   // ARM.FreeRTOS::RTOS:Core
 #include "task.h"                       // ARM.FreeRTOS::RTOS:Core
 #include "event_groups.h"               // ARM.FreeRTOS::RTOS:Event Groups
 #include "semphr.h"                     // ARM.FreeRTOS::RTOS:Core
+
+#include "freertos_mpool.h"             // osMemoryPool definitions
+#include "freertos_os2.h"               // Configuration check and setup
 
 /*---------------------------------------------------------------------------*/
 #ifndef __ARM_ARCH_6M__
@@ -73,7 +75,9 @@
 #define IS_IRQ_MODE()             (__get_IPSR() != 0U)
 #endif
 
-#define IS_IRQ()                  (IS_IRQ_MODE() || (IS_IRQ_MASKED() && (KernelState == osKernelRunning)))
+#define IS_IRQ()                  IS_IRQ_MODE()
+
+#define SVCall_IRQ_NBR            (IRQn_Type) -5	/* SVCall_IRQ_NBR added as SV_Call handler name is not the same for CM0 and for all other CMx */
 
 /* Limits */
 #define MAX_BITS_TASK_NOTIFY      31U
@@ -108,7 +112,7 @@ static osKernelState_t KernelState = osKernelInactive;
   definition configHEAP_5_REGIONS as parameter. Overriding configHEAP_5_REGIONS
   is possible by defining it globally or in FreeRTOSConfig.h.
 */
-#if defined(USE_FREERTOS_HEAP_5)
+#if defined(USE_FreeRTOS_HEAP_5)
 #if (configAPPLICATION_ALLOCATED_HEAP == 0)
   /*
     FreeRTOS heap is not defined by the application.
@@ -138,7 +142,7 @@ static osKernelState_t KernelState = osKernelInactive;
   */
   #define HEAP_5_REGION_SETUP   0
 #endif /* configAPPLICATION_ALLOCATED_HEAP */
-#endif /* USE_FREERTOS_HEAP_5 */
+#endif /* USE_FreeRTOS_HEAP_5 */
 
 #if defined(SysTick)
 #undef SysTick_Handler
@@ -148,11 +152,11 @@ extern void SysTick_Handler     (void);
 /* FreeRTOS tick timer interrupt handler prototype */
 extern void xPortSysTickHandler (void);
 
-/* SysTick handler implementation done in the core and call osSystickHandler */
-#ifndef ARDUINO_ARCH_STM32
 /*
   SysTick handler implementation that also clears overflow flag.
 */
+/* SysTick handler implementation done in the core and call osSystickHandler */
+#ifndef ARDUINO_ARCH_STM32 && (USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION == 0)
 void SysTick_Handler (void) {
   /* Clear overflow flag */
   SysTick->CTRL;
@@ -162,7 +166,7 @@ void SysTick_Handler (void) {
     xPortSysTickHandler();
   }
 }
-#endif /* ARDUINO_ARCH_STM32 */
+#endif /* ARDUINO_ARCH_STM32 && USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION == 0*/
 #endif /* SysTick */
 
 /*
@@ -173,16 +177,23 @@ __STATIC_INLINE void SVC_Setup (void) {
   /* Service Call interrupt might be configured before kernel start     */
   /* and when its priority is lower or equal to BASEPRI, svc intruction */
   /* causes a Hard Fault.                                               */
-
- /*
-  * the call below has introduced a regression compared to revious release
-  * The issue was logged under:https://github.com/ARM-software/CMSIS-FreeRTOS/issues/35
-  * until it is correctly fixed, the code below is commented
-  */
-/*    NVIC_SetPriority (SVCall_IRQn, 0U); */
+  NVIC_SetPriority (SVCall_IRQ_NBR, 0U);
 #endif
 }
 
+/*
+  Function macro used to retrieve semaphore count from ISR
+*/
+#ifndef uxSemaphoreGetCountFromISR
+#define uxSemaphoreGetCountFromISR( xSemaphore ) uxQueueMessagesWaitingFromISR( ( QueueHandle_t ) ( xSemaphore ) )
+#endif
+
+/* Get OS Tick count value */
+static uint32_t OS_Tick_GetCount (void);
+/* Get OS Tick overflow status */
+static uint32_t OS_Tick_GetOverflow (void);
+/* Get OS Tick interval */
+static uint32_t OS_Tick_GetInterval (void);
 /*---------------------------------------------------------------------------*/
 
 osStatus_t osKernelInitialize (void) {
@@ -193,7 +204,10 @@ osStatus_t osKernelInitialize (void) {
   }
   else {
     if (KernelState == osKernelInactive) {
-      #if defined(USE_FREERTOS_HEAP_5) && (HEAP_5_REGION_SETUP == 1)
+      #if defined(USE_TRACE_EVENT_RECORDER)
+        EvrFreeRTOSSetup(0U);
+      #endif
+      #if defined(USE_FreeRTOS_HEAP_5) && (HEAP_5_REGION_SETUP == 1)
         vPortDefineHeapRegions (configHEAP_5_REGIONS);
       #endif
       KernelState = osKernelReady;
@@ -383,6 +397,22 @@ uint32_t osKernelGetTickFreq (void) {
   return (configTICK_RATE_HZ);
 }
 
+/* Get OS Tick count value */
+static uint32_t OS_Tick_GetCount (void) {
+  uint32_t load = SysTick->LOAD;
+  return  (load - SysTick->VAL);
+}
+
+/* Get OS Tick overflow status */
+static uint32_t OS_Tick_GetOverflow (void) {
+  return ((SysTick->CTRL >> 16) & 1U);
+}
+
+/* Get OS Tick interval */
+static uint32_t OS_Tick_GetInterval (void) {
+  return (SysTick->LOAD + 1U);
+}
+
 uint32_t osKernelGetSysTimerCount (void) {
   uint32_t irqmask = IS_IRQ_MASKED();
   TickType_t ticks;
@@ -391,8 +421,14 @@ uint32_t osKernelGetSysTimerCount (void) {
   __disable_irq();
 
   ticks = xTaskGetTickCount();
+  val   = OS_Tick_GetCount();
 
-  val = ticks * ( configCPU_CLOCK_HZ / configTICK_RATE_HZ );
+  if (OS_Tick_GetOverflow() != 0U) {
+    val = OS_Tick_GetCount();
+    ticks++;
+  }
+  val += ticks * OS_Tick_GetInterval();
+
   if (irqmask == 0U) {
     __enable_irq();
   }
@@ -455,14 +491,18 @@ osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAtt
     }
 
     if (mem == 1) {
-      hTask = xTaskCreateStatic ((TaskFunction_t)func, name, stack, argument, prio, (StackType_t  *)attr->stack_mem,
-                                                                                    (StaticTask_t *)attr->cb_mem);
+      #if (configSUPPORT_STATIC_ALLOCATION == 1)
+        hTask = xTaskCreateStatic ((TaskFunction_t)func, name, stack, argument, prio, (StackType_t  *)attr->stack_mem,
+                                                                                      (StaticTask_t *)attr->cb_mem);
+      #endif
     }
     else {
       if (mem == 0) {
-        if (xTaskCreate ((TaskFunction_t)func, name, (uint16_t)stack, argument, prio, &hTask) != pdPASS) {
-          hTask = NULL;
-        }
+        #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+          if (xTaskCreate ((TaskFunction_t)func, name, (uint16_t)stack, argument, prio, &hTask) != pdPASS) {
+            hTask = NULL;
+          }
+        #endif
       }
     }
   }
@@ -520,7 +560,7 @@ uint32_t osThreadGetStackSpace (osThreadId_t thread_id) {
   if (IS_IRQ() || (hTask == NULL)) {
     sz = 0U;
   } else {
-    sz = (uint32_t)uxTaskGetStackHighWaterMark (hTask);
+    sz = (uint32_t)(uxTaskGetStackHighWaterMark(hTask) * sizeof(StackType_t));
   }
 
   return (sz);
@@ -551,7 +591,7 @@ osPriority_t osThreadGetPriority (osThreadId_t thread_id) {
   if (IS_IRQ() || (hTask == NULL)) {
     prio = osPriorityError;
   } else {
-    prio = (osPriority_t)uxTaskPriorityGet (hTask);
+    prio = (osPriority_t)((int32_t)uxTaskPriorityGet (hTask));
   }
 
   return (prio);
@@ -570,6 +610,7 @@ osStatus_t osThreadYield (void) {
   return (stat);
 }
 
+#if (configUSE_OS2_THREAD_SUSPEND_RESUME == 1)
 osStatus_t osThreadSuspend (osThreadId_t thread_id) {
   TaskHandle_t hTask = (TaskHandle_t)thread_id;
   osStatus_t stat;
@@ -605,6 +646,7 @@ osStatus_t osThreadResume (osThreadId_t thread_id) {
 
   return (stat);
 }
+#endif /* (configUSE_OS2_THREAD_SUSPEND_RESUME == 1) */
 
 __NO_RETURN void osThreadExit (void) {
 #ifndef USE_FreeRTOS_HEAP_1
@@ -654,6 +696,7 @@ uint32_t osThreadGetCount (void) {
   return (count);
 }
 
+#if (configUSE_OS2_THREAD_ENUMERATE == 1)
 uint32_t osThreadEnumerate (osThreadId_t *thread_array, uint32_t array_items) {
   uint32_t i, count;
   TaskStatus_t *task;
@@ -681,7 +724,9 @@ uint32_t osThreadEnumerate (osThreadId_t *thread_array, uint32_t array_items) {
 
   return (count);
 }
+#endif /* (configUSE_OS2_THREAD_ENUMERATE == 1) */
 
+#if (configUSE_OS2_THREAD_FLAGS == 1)
 uint32_t osThreadFlagsSet (osThreadId_t thread_id, uint32_t flags) {
   TaskHandle_t hTask = (TaskHandle_t)thread_id;
   uint32_t rflags;
@@ -832,6 +877,7 @@ uint32_t osThreadFlagsWait (uint32_t flags, uint32_t options, uint32_t timeout) 
   /* Return flags before clearing */
   return (rflags);
 }
+#endif /* (configUSE_OS2_THREAD_FLAGS == 1) */
 
 osStatus_t osDelay (uint32_t ticks) {
   osStatus_t stat;
@@ -879,6 +925,7 @@ osStatus_t osDelayUntil (uint32_t ticks) {
 }
 
 /*---------------------------------------------------------------------------*/
+#if (configUSE_OS2_TIMER == 1)
 
 static void TimerCallback (TimerHandle_t hTimer) {
   TimerCallback_t *callb;
@@ -935,12 +982,20 @@ osTimerId_t osTimerNew (osTimerFunc_t func, osTimerType_t type, void *argument, 
       }
 
       if (mem == 1) {
-        hTimer = xTimerCreateStatic (name, 1, reload, callb, TimerCallback, (StaticTimer_t *)attr->cb_mem);
+        #if (configSUPPORT_STATIC_ALLOCATION == 1)
+          hTimer = xTimerCreateStatic (name, 1, reload, callb, TimerCallback, (StaticTimer_t *)attr->cb_mem);
+        #endif
       }
       else {
         if (mem == 0) {
-          hTimer = xTimerCreate (name, 1, reload, callb, TimerCallback);
+          #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+            hTimer = xTimerCreate (name, 1, reload, callb, TimerCallback);
+          #endif
         }
+      }
+
+      if ((hTimer == NULL) && (callb != NULL)) {
+        vPortFree (callb);
       }
     }
   }
@@ -1049,6 +1104,7 @@ osStatus_t osTimerDelete (osTimerId_t timer_id) {
 
   return (stat);
 }
+#endif /* (configUSE_OS2_TIMER == 1) */
 
 /*---------------------------------------------------------------------------*/
 
@@ -1076,11 +1132,15 @@ osEventFlagsId_t osEventFlagsNew (const osEventFlagsAttr_t *attr) {
     }
 
     if (mem == 1) {
+      #if (configSUPPORT_STATIC_ALLOCATION == 1)
       hEventGroup = xEventGroupCreateStatic (attr->cb_mem);
+      #endif
     }
     else {
       if (mem == 0) {
-        hEventGroup = xEventGroupCreate();
+        #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+          hEventGroup = xEventGroupCreate();
+        #endif
       }
     }
   }
@@ -1097,6 +1157,11 @@ uint32_t osEventFlagsSet (osEventFlagsId_t ef_id, uint32_t flags) {
     rflags = (uint32_t)osErrorParameter;
   }
   else if (IS_IRQ()) {
+  #if (configUSE_OS2_EVENTFLAGS_FROM_ISR == 0)
+    (void)yield;
+    /* Enable timers and xTimerPendFunctionCall function to support osEventFlagsSet from ISR */
+    rflags = (uint32_t)osErrorResource;
+  #else
     yield = pdFALSE;
 
     if (xEventGroupSetBitsFromISR (hEventGroup, (EventBits_t)flags, &yield) == pdFAIL) {
@@ -1105,6 +1170,7 @@ uint32_t osEventFlagsSet (osEventFlagsId_t ef_id, uint32_t flags) {
       rflags = flags;
       portYIELD_FROM_ISR (yield);
     }
+  #endif
   }
   else {
     rflags = xEventGroupSetBits (hEventGroup, (EventBits_t)flags);
@@ -1121,11 +1187,16 @@ uint32_t osEventFlagsClear (osEventFlagsId_t ef_id, uint32_t flags) {
     rflags = (uint32_t)osErrorParameter;
   }
   else if (IS_IRQ()) {
+  #if (configUSE_OS2_EVENTFLAGS_FROM_ISR == 0)
+    /* Enable timers and xTimerPendFunctionCall function to support osEventFlagsSet from ISR */
+    rflags = (uint32_t)osErrorResource;
+  #else
     rflags = xEventGroupGetBitsFromISR (hEventGroup);
 
     if (xEventGroupClearBitsFromISR (hEventGroup, (EventBits_t)flags) == pdFAIL) {
       rflags = (uint32_t)osErrorResource;
     }
+  #endif
   }
   else {
     rflags = xEventGroupClearBits (hEventGroup, (EventBits_t)flags);
@@ -1179,7 +1250,7 @@ uint32_t osEventFlagsWait (osEventFlagsId_t ef_id, uint32_t flags, uint32_t opti
     rflags = xEventGroupWaitBits (hEventGroup, (EventBits_t)flags, exit_clr, wait_all, (TickType_t)timeout);
 
     if (options & osFlagsWaitAll) {
-      if (flags != rflags) {
+      if ((flags & rflags) != flags) {
         if (timeout > 0U) {
           rflags = (uint32_t)osErrorTimeout;
         } else {
@@ -1224,6 +1295,7 @@ osStatus_t osEventFlagsDelete (osEventFlagsId_t ef_id) {
 }
 
 /*---------------------------------------------------------------------------*/
+#if (configUSE_OS2_MUTEX == 1)
 
 osMutexId_t osMutexNew (const osMutexAttr_t *attr) {
   SemaphoreHandle_t hMutex;
@@ -1267,20 +1339,28 @@ osMutexId_t osMutexNew (const osMutexAttr_t *attr) {
       }
 
       if (mem == 1) {
-        if (rmtx != 0U) {
-          hMutex = xSemaphoreCreateRecursiveMutexStatic (attr->cb_mem);
-        }
-        else {
-          hMutex = xSemaphoreCreateMutexStatic (attr->cb_mem);
-        }
+        #if (configSUPPORT_STATIC_ALLOCATION == 1)
+          if (rmtx != 0U) {
+            #if (configUSE_RECURSIVE_MUTEXES == 1)
+            hMutex = xSemaphoreCreateRecursiveMutexStatic (attr->cb_mem);
+            #endif
+          }
+          else {
+            hMutex = xSemaphoreCreateMutexStatic (attr->cb_mem);
+          }
+        #endif
       }
       else {
         if (mem == 0) {
-          if (rmtx != 0U) {
-            hMutex = xSemaphoreCreateRecursiveMutex ();
-          } else {
-            hMutex = xSemaphoreCreateMutex ();
-          }
+          #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+            if (rmtx != 0U) {
+              #if (configUSE_RECURSIVE_MUTEXES == 1)
+              hMutex = xSemaphoreCreateRecursiveMutex ();
+              #endif
+            } else {
+              hMutex = xSemaphoreCreateMutex ();
+            }
+          #endif
         }
       }
 
@@ -1323,6 +1403,7 @@ osStatus_t osMutexAcquire (osMutexId_t mutex_id, uint32_t timeout) {
   }
   else {
     if (rmtx != 0U) {
+      #if (configUSE_RECURSIVE_MUTEXES == 1)
       if (xSemaphoreTakeRecursive (hMutex, timeout) != pdPASS) {
         if (timeout != 0U) {
           stat = osErrorTimeout;
@@ -1330,6 +1411,7 @@ osStatus_t osMutexAcquire (osMutexId_t mutex_id, uint32_t timeout) {
           stat = osErrorResource;
         }
       }
+      #endif
     }
     else {
       if (xSemaphoreTake (hMutex, timeout) != pdPASS) {
@@ -1364,9 +1446,11 @@ osStatus_t osMutexRelease (osMutexId_t mutex_id) {
   }
   else {
     if (rmtx != 0U) {
+      #if (configUSE_RECURSIVE_MUTEXES == 1)
       if (xSemaphoreGiveRecursive (hMutex) != pdPASS) {
         stat = osErrorResource;
       }
+      #endif
     }
     else {
       if (xSemaphoreGive (hMutex) != pdPASS) {
@@ -1419,6 +1503,7 @@ osStatus_t osMutexDelete (osMutexId_t mutex_id) {
 
   return (stat);
 }
+#endif /* (configUSE_OS2_MUTEX == 1) */
 
 /*---------------------------------------------------------------------------*/
 
@@ -1451,10 +1536,14 @@ osSemaphoreId_t osSemaphoreNew (uint32_t max_count, uint32_t initial_count, cons
     if (mem != -1) {
       if (max_count == 1U) {
         if (mem == 1) {
-          hSemaphore = xSemaphoreCreateBinaryStatic ((StaticSemaphore_t *)attr->cb_mem);
+          #if (configSUPPORT_STATIC_ALLOCATION == 1)
+            hSemaphore = xSemaphoreCreateBinaryStatic ((StaticSemaphore_t *)attr->cb_mem);
+          #endif
         }
         else {
-          hSemaphore = xSemaphoreCreateBinary();
+          #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+            hSemaphore = xSemaphoreCreateBinary();
+          #endif
         }
 
         if ((hSemaphore != NULL) && (initial_count != 0U)) {
@@ -1466,13 +1555,17 @@ osSemaphoreId_t osSemaphoreNew (uint32_t max_count, uint32_t initial_count, cons
       }
       else {
         if (mem == 1) {
-          hSemaphore = xSemaphoreCreateCountingStatic (max_count, initial_count, (StaticSemaphore_t *)attr->cb_mem);
+          #if (configSUPPORT_STATIC_ALLOCATION == 1)
+            hSemaphore = xSemaphoreCreateCountingStatic (max_count, initial_count, (StaticSemaphore_t *)attr->cb_mem);
+          #endif
         }
         else {
-          hSemaphore = xSemaphoreCreateCounting (max_count, initial_count);
+          #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+            hSemaphore = xSemaphoreCreateCounting (max_count, initial_count);
+          #endif
         }
       }
-
+      
       #if (configQUEUE_REGISTRY_SIZE > 0)
       if (hSemaphore != NULL) {
         if (attr != NULL) {
@@ -1627,11 +1720,15 @@ osMessageQueueId_t osMessageQueueNew (uint32_t msg_count, uint32_t msg_size, con
     }
 
     if (mem == 1) {
-      hQueue = xQueueCreateStatic (msg_count, msg_size, attr->mq_mem, attr->cb_mem);
+      #if (configSUPPORT_STATIC_ALLOCATION == 1)
+        hQueue = xQueueCreateStatic (msg_count, msg_size, attr->mq_mem, attr->cb_mem);
+      #endif
     }
     else {
       if (mem == 0) {
-        hQueue = xQueueCreate (msg_count, msg_size);
+        #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+          hQueue = xQueueCreate (msg_count, msg_size);
+        #endif
       }
     }
 
@@ -1846,6 +1943,463 @@ osStatus_t osMessageQueueDelete (osMessageQueueId_t mq_id) {
 }
 
 /*---------------------------------------------------------------------------*/
+#ifdef FREERTOS_MPOOL_H_
+
+/* Static memory pool functions */
+static void  FreeBlock   (MemPool_t *mp, void *block);
+static void *AllocBlock  (MemPool_t *mp);
+static void *CreateBlock (MemPool_t *mp);
+
+osMemoryPoolId_t osMemoryPoolNew (uint32_t block_count, uint32_t block_size, const osMemoryPoolAttr_t *attr) {
+  MemPool_t *mp;
+  const char *name;
+  int32_t mem_cb, mem_mp;
+  uint32_t sz;
+
+  if (IS_IRQ()) {
+    mp = NULL;
+  }
+  else if ((block_count == 0U) || (block_size == 0U)) {
+    mp = NULL;
+  }
+  else {
+    mp = NULL;
+    sz = MEMPOOL_ARR_SIZE (block_count, block_size);
+
+    name = NULL;
+    mem_cb = -1;
+    mem_mp = -1;
+
+    if (attr != NULL) {
+      if (attr->name != NULL) {
+        name = attr->name;
+      }
+
+      if ((attr->cb_mem != NULL) && (attr->cb_size >= sizeof(MemPool_t))) {
+        /* Static control block is provided */
+        mem_cb = 1;
+      }
+      else if ((attr->cb_mem == NULL) && (attr->cb_size == 0U)) {
+        /* Allocate control block memory on heap */
+        mem_cb = 0;
+      }
+
+      if ((attr->mp_mem == NULL) && (attr->mp_size == 0U)) {
+        /* Allocate memory array on heap */
+          mem_mp = 0;
+      }
+      else {
+        if (attr->mp_mem != NULL) {
+          /* Check if array is 4-byte aligned */
+          if (((uint32_t)attr->mp_mem & 3U) == 0U) {
+            /* Check if array big enough */
+            if (attr->mp_size >= sz) {
+              /* Static memory pool array is provided */
+              mem_mp = 1;
+            }
+          }
+        }
+      }
+    }
+    else {
+      /* Attributes not provided, allocate memory on heap */
+      mem_cb = 0;
+      mem_mp = 0;
+    }
+
+    if (mem_cb == 0) {
+      mp = pvPortMalloc (sizeof(MemPool_t));
+    } else {
+      mp = attr->cb_mem;
+    }
+
+    if (mp != NULL) {
+      /* Create a semaphore (max count == initial count == block_count) */
+      #if (configSUPPORT_STATIC_ALLOCATION == 1)
+        mp->sem = xSemaphoreCreateCountingStatic (block_count, block_count, &mp->mem_sem);
+      #elif (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+        mp->sem = xSemaphoreCreateCounting (block_count, block_count);
+      #else
+        mp->sem == NULL;
+      #endif
+
+      if (mp->sem != NULL) {
+        /* Setup memory array */
+        if (mem_mp == 0) {
+          mp->mem_arr = pvPortMalloc (sz);
+        } else {
+          mp->mem_arr = attr->mp_mem;
+        }
+      }
+    }
+
+    if ((mp != NULL) && (mp->mem_arr != NULL)) {
+      /* Memory pool can be created */
+      mp->head    = NULL;
+      mp->mem_sz  = sz;
+      mp->name    = name;
+      mp->bl_sz   = block_size;
+      mp->bl_cnt  = block_count;
+      mp->n       = 0U;
+
+      /* Set heap allocated memory flags */
+      mp->status = MPOOL_STATUS;
+
+      if (mem_cb == 0) {
+        /* Control block on heap */
+        mp->status |= 1U;
+      }
+      if (mem_mp == 0) {
+        /* Memory array on heap */
+        mp->status |= 2U;
+      }
+    }
+    else {
+      /* Memory pool cannot be created, release allocated resources */
+      if ((mem_cb == 0) && (mp != NULL)) {
+        /* Free control block memory */
+        vPortFree (mp);
+      }
+      mp = NULL;
+    }
+  }
+
+  return (mp);
+}
+
+const char *osMemoryPoolGetName (osMemoryPoolId_t mp_id) {
+  MemPool_t *mp = (osMemoryPoolId_t)mp_id;
+  const char *p;
+
+  if (IS_IRQ()) {
+    p = NULL;
+  }
+  else if (mp_id == NULL) {
+    p = NULL;
+  }
+  else {
+    p = mp->name;
+  }
+
+  return (p);
+}
+
+void *osMemoryPoolAlloc (osMemoryPoolId_t mp_id, uint32_t timeout) {
+  MemPool_t *mp;
+  void *block;
+  uint32_t isrm;
+
+  if (mp_id == NULL) {
+    /* Invalid input parameters */
+    block = NULL;
+  }
+  else {
+    block = NULL;
+
+    mp = (MemPool_t *)mp_id;
+
+    if ((mp->status & MPOOL_STATUS) == MPOOL_STATUS) {
+      if (IS_IRQ()) {
+        if (timeout == 0U) {
+          if (xSemaphoreTakeFromISR (mp->sem, NULL) == pdTRUE) {
+            if ((mp->status & MPOOL_STATUS) == MPOOL_STATUS) {
+              isrm  = taskENTER_CRITICAL_FROM_ISR();
+
+              /* Get a block from the free-list */
+              block = AllocBlock(mp);
+
+              if (block == NULL) {
+                /* List of free blocks is empty, 'create' new block */
+                block = CreateBlock(mp);
+              }
+
+              taskEXIT_CRITICAL_FROM_ISR(isrm);
+            }
+          }
+        }
+      }
+      else {
+        if (xSemaphoreTake (mp->sem, (TickType_t)timeout) == pdTRUE) {
+          if ((mp->status & MPOOL_STATUS) == MPOOL_STATUS) {
+            taskENTER_CRITICAL();
+
+            /* Get a block from the free-list */
+            block = AllocBlock(mp);
+
+            if (block == NULL) {
+              /* List of free blocks is empty, 'create' new block */
+              block = CreateBlock(mp);
+            }
+
+            taskEXIT_CRITICAL();
+          }
+        }
+      }
+    }
+  }
+
+  return (block);
+}
+
+osStatus_t osMemoryPoolFree (osMemoryPoolId_t mp_id, void *block) {
+  MemPool_t *mp;
+  osStatus_t stat;
+  uint32_t isrm;
+  BaseType_t yield;
+
+  if ((mp_id == NULL) || (block == NULL)) {
+    /* Invalid input parameters */
+    stat = osErrorParameter;
+  }
+  else {
+    mp = (MemPool_t *)mp_id;
+
+    if ((mp->status & MPOOL_STATUS) != MPOOL_STATUS) {
+      /* Invalid object status */
+      stat = osErrorResource;
+    }
+    else if ((block < (void *)&mp->mem_arr[0]) || (block > (void*)&mp->mem_arr[mp->mem_sz-1])) {
+      /* Block pointer outside of memory array area */
+      stat = osErrorParameter;
+    }
+    else {
+      stat = osOK;
+
+      if (IS_IRQ()) {
+        if (uxSemaphoreGetCountFromISR (mp->sem) == mp->bl_cnt) {
+          stat = osErrorResource;
+        }
+        else {
+          isrm = taskENTER_CRITICAL_FROM_ISR();
+
+          /* Add block to the list of free blocks */
+          FreeBlock(mp, block);
+
+          taskEXIT_CRITICAL_FROM_ISR(isrm);
+
+          yield = pdFALSE;
+          xSemaphoreGiveFromISR (mp->sem, &yield);
+          portYIELD_FROM_ISR (yield);
+        }
+      }
+      else {
+        if (uxSemaphoreGetCount (mp->sem) == mp->bl_cnt) {
+          stat = osErrorResource;
+        }
+        else {
+          taskENTER_CRITICAL();
+
+          /* Add block to the list of free blocks */
+          FreeBlock(mp, block);
+
+          taskEXIT_CRITICAL();
+
+          xSemaphoreGive (mp->sem);
+        }
+      }
+    }
+  }
+
+  return (stat);
+}
+
+uint32_t osMemoryPoolGetCapacity (osMemoryPoolId_t mp_id) {
+  MemPool_t *mp;
+  uint32_t  n;
+
+  if (mp_id == NULL) {
+    /* Invalid input parameters */
+    n = 0U;
+  }
+  else {
+    mp = (MemPool_t *)mp_id;
+
+    if ((mp->status & MPOOL_STATUS) != MPOOL_STATUS) {
+      /* Invalid object status */
+      n = 0U;
+    }
+    else {
+      n = mp->bl_cnt;
+    }
+  }
+
+  /* Return maximum number of memory blocks */
+  return (n);
+}
+
+uint32_t osMemoryPoolGetBlockSize (osMemoryPoolId_t mp_id) {
+  MemPool_t *mp;
+  uint32_t  sz;
+
+  if (mp_id == NULL) {
+    /* Invalid input parameters */
+    sz = 0U;
+  }
+  else {
+    mp = (MemPool_t *)mp_id;
+
+    if ((mp->status & MPOOL_STATUS) != MPOOL_STATUS) {
+      /* Invalid object status */
+      sz = 0U;
+    }
+    else {
+      sz = mp->bl_sz;
+    }
+  }
+
+  /* Return memory block size in bytes */
+  return (sz);
+}
+
+uint32_t osMemoryPoolGetCount (osMemoryPoolId_t mp_id) {
+  MemPool_t *mp;
+  uint32_t  n;
+
+  if (mp_id == NULL) {
+    /* Invalid input parameters */
+    n = 0U;
+  }
+  else {
+    mp = (MemPool_t *)mp_id;
+
+    if ((mp->status & MPOOL_STATUS) != MPOOL_STATUS) {
+      /* Invalid object status */
+      n = 0U;
+    }
+    else {
+      if (IS_IRQ()) {
+        n = uxSemaphoreGetCountFromISR (mp->sem);
+      } else {
+        n = uxSemaphoreGetCount        (mp->sem);
+      }
+
+      n = mp->bl_cnt - n;
+    }
+  }
+
+  /* Return number of memory blocks used */
+  return (n);
+}
+
+uint32_t osMemoryPoolGetSpace (osMemoryPoolId_t mp_id) {
+  MemPool_t *mp;
+  uint32_t  n;
+
+  if (mp_id == NULL) {
+    /* Invalid input parameters */
+    n = 0U;
+  }
+  else {
+    mp = (MemPool_t *)mp_id;
+
+    if ((mp->status & MPOOL_STATUS) != MPOOL_STATUS) {
+      /* Invalid object status */
+      n = 0U;
+    }
+    else {
+      if (IS_IRQ()) {
+        n = uxSemaphoreGetCountFromISR (mp->sem);
+      } else {
+        n = uxSemaphoreGetCount        (mp->sem);
+      }
+    }
+  }
+
+  /* Return number of memory blocks available */
+  return (n);
+}
+
+osStatus_t osMemoryPoolDelete (osMemoryPoolId_t mp_id) {
+  MemPool_t *mp;
+  osStatus_t stat;
+
+  if (mp_id == NULL) {
+    /* Invalid input parameters */
+    stat = osErrorParameter;
+  }
+  else if (IS_IRQ()) {
+    stat = osErrorISR;
+  }
+  else {
+    mp = (MemPool_t *)mp_id;
+
+    taskENTER_CRITICAL();
+
+    /* Invalidate control block status */
+    mp->status  = mp->status & 3U;
+
+    /* Wake-up tasks waiting for pool semaphore */
+    while (xSemaphoreGive (mp->sem) == pdTRUE);
+
+    mp->head    = NULL;
+    mp->bl_sz   = 0U;
+    mp->bl_cnt  = 0U;
+
+    if ((mp->status & 2U) != 0U) {
+      /* Memory pool array allocated on heap */
+      vPortFree (mp->mem_arr);
+    }
+    if ((mp->status & 1U) != 0U) {
+      /* Memory pool control block allocated on heap */
+      vPortFree (mp);
+    }
+
+    taskEXIT_CRITICAL();
+
+    stat = osOK;
+  }
+
+  return (stat);
+}
+
+/*
+  Create new block given according to the current block index.
+*/
+static void *CreateBlock (MemPool_t *mp) {
+  MemPoolBlock_t *p = NULL;
+
+  if (mp->n < mp->bl_cnt) {
+    /* Unallocated blocks exist, set pointer to new block */
+    p = (void *)(mp->mem_arr + (mp->bl_sz * mp->n));
+
+    /* Increment block index */
+    mp->n += 1U;
+  }
+
+  return (p);
+}
+
+/*
+  Allocate a block by reading the list of free blocks.
+*/
+static void *AllocBlock (MemPool_t *mp) {
+  MemPoolBlock_t *p = NULL;
+
+  if (mp->head != NULL) {
+    /* List of free block exists, get head block */
+    p = mp->head;
+
+    /* Head block is now next on the list */
+    mp->head = p->next;
+  }
+
+  return (p);
+}
+
+/*
+  Free block by putting it to the list of free blocks.
+*/
+static void FreeBlock (MemPool_t *mp, void *block) {
+  MemPoolBlock_t *p = block;
+
+  /* Store current head into block memory space */
+  p->next = mp->head;
+
+  /* Store current block as new head */
+  mp->head = p;
+}
+#endif /* FREERTOS_MPOOL_H_ */
+/*---------------------------------------------------------------------------*/
 
 /* Callback function prototypes */
 extern void vApplicationIdleHook (void);
@@ -1889,28 +2443,25 @@ __WEAK void vApplicationDaemonTaskStartupHook (void){}
 __WEAK void vApplicationStackOverflowHook (TaskHandle_t xTask, signed char *pcTaskName) {
   (void)xTask;
   (void)pcTaskName;
+  configASSERT(0);
 }
 #endif
 
 /*---------------------------------------------------------------------------*/
-
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
 /* External Idle and Timer task static memory allocation functions */
 extern void vApplicationGetIdleTaskMemory  (StaticTask_t **ppxIdleTaskTCBBuffer,  StackType_t **ppxIdleTaskStackBuffer,  uint32_t *pulIdleTaskStackSize);
 extern void vApplicationGetTimerTaskMemory (StaticTask_t **ppxTimerTaskTCBBuffer, StackType_t **ppxTimerTaskStackBuffer, uint32_t *pulTimerTaskStackSize);
-
-/* Idle task control block and stack */
-static StaticTask_t Idle_TCB;
-static StackType_t  Idle_Stack[configMINIMAL_STACK_SIZE];
-
-/* Timer task control block and stack */
-static StaticTask_t Timer_TCB;
-static StackType_t  Timer_Stack[configTIMER_TASK_STACK_DEPTH];
 
 /*
   vApplicationGetIdleTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
   equals to 1 and is required for static memory allocation support.
 */
-void vApplicationGetIdleTaskMemory (StaticTask_t **ppxIdleTaskTCBBuffer, StackType_t **ppxIdleTaskStackBuffer, uint32_t *pulIdleTaskStackSize) {
+__WEAK void vApplicationGetIdleTaskMemory (StaticTask_t **ppxIdleTaskTCBBuffer, StackType_t **ppxIdleTaskStackBuffer, uint32_t *pulIdleTaskStackSize) {
+  /* Idle task control block and stack */
+  static StaticTask_t Idle_TCB;
+  static StackType_t  Idle_Stack[configMINIMAL_STACK_SIZE];
+
   *ppxIdleTaskTCBBuffer   = &Idle_TCB;
   *ppxIdleTaskStackBuffer = &Idle_Stack[0];
   *pulIdleTaskStackSize   = (uint32_t)configMINIMAL_STACK_SIZE;
@@ -1920,8 +2471,13 @@ void vApplicationGetIdleTaskMemory (StaticTask_t **ppxIdleTaskTCBBuffer, StackTy
   vApplicationGetTimerTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
   equals to 1 and is required for static memory allocation support.
 */
-void vApplicationGetTimerTaskMemory (StaticTask_t **ppxTimerTaskTCBBuffer, StackType_t **ppxTimerTaskStackBuffer, uint32_t *pulTimerTaskStackSize) {
+__WEAK void vApplicationGetTimerTaskMemory (StaticTask_t **ppxTimerTaskTCBBuffer, StackType_t **ppxTimerTaskStackBuffer, uint32_t *pulTimerTaskStackSize) {
+  /* Timer task control block and stack */
+  static StaticTask_t Timer_TCB;
+  static StackType_t  Timer_Stack[configTIMER_TASK_STACK_DEPTH];
+
   *ppxTimerTaskTCBBuffer   = &Timer_TCB;
   *ppxTimerTaskStackBuffer = &Timer_Stack[0];
   *pulTimerTaskStackSize   = (uint32_t)configTIMER_TASK_STACK_DEPTH;
 }
+#endif

--- a/portable/CMSIS_RTOS_V2/cmsis_os2.c
+++ b/portable/CMSIS_RTOS_V2/cmsis_os2.c
@@ -156,7 +156,7 @@ extern void xPortSysTickHandler (void);
   SysTick handler implementation that also clears overflow flag.
 */
 /* SysTick handler implementation done in the core and call osSystickHandler */
-#ifndef ARDUINO_ARCH_STM32 && (USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION == 0)
+#if !defined(ARDUINO_ARCH_STM32) && (USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION == 0)
 void SysTick_Handler (void) {
   /* Clear overflow flag */
   SysTick->CTRL;
@@ -166,7 +166,7 @@ void SysTick_Handler (void) {
     xPortSysTickHandler();
   }
 }
-#endif /* ARDUINO_ARCH_STM32 && USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION == 0*/
+#endif /* !ARDUINO_ARCH_STM32 && (USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION == 0)*/
 #endif /* SysTick */
 
 /*

--- a/portable/CMSIS_RTOS_V2/freertos_mpool.h
+++ b/portable/CMSIS_RTOS_V2/freertos_mpool.h
@@ -1,0 +1,63 @@
+/* --------------------------------------------------------------------------
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *      Name:    freertos_mpool.h
+ *      Purpose: CMSIS RTOS2 wrapper for FreeRTOS
+ *
+ *---------------------------------------------------------------------------*/
+
+#ifndef FREERTOS_MPOOL_H_
+#define FREERTOS_MPOOL_H_
+
+#include <stdint.h>
+#include "FreeRTOS.h"
+#include "semphr.h"
+
+/* Memory Pool implementation definitions */
+#define MPOOL_STATUS              0x5EED0000U
+
+/* Memory Block header */
+typedef struct {
+  void *next;                   /* Pointer to next block  */
+} MemPoolBlock_t;
+
+/* Memory Pool control block */
+typedef struct MemPoolDef_t {
+  MemPoolBlock_t    *head;      /* Pointer to head block   */
+  SemaphoreHandle_t  sem;       /* Pool semaphore handle   */
+  uint8_t           *mem_arr;   /* Pool memory array       */
+  uint32_t           mem_sz;    /* Pool memory array size  */
+  const char        *name;      /* Pointer to name string  */
+  uint32_t           bl_sz;     /* Size of a single block  */
+  uint32_t           bl_cnt;    /* Number of blocks        */
+  uint32_t           n;         /* Block allocation index  */
+  volatile uint32_t  status;    /* Object status flags     */
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+  StaticSemaphore_t  mem_sem;   /* Semaphore object memory */
+#endif
+} MemPool_t;
+
+/* No need to hide static object type, just align to coding style */
+#define StaticMemPool_t         MemPool_t
+
+/* Define memory pool control block size */
+#define MEMPOOL_CB_SIZE         (sizeof(StaticMemPool_t))
+
+/* Define size of the byte array required to create count of blocks of given size */
+#define MEMPOOL_ARR_SIZE(bl_count, bl_size) (((((bl_size) + (4 - 1)) / 4) * 4)*(bl_count))
+
+#endif /* FREERTOS_MPOOL_H_ */

--- a/portable/CMSIS_RTOS_V2/freertos_os2.h
+++ b/portable/CMSIS_RTOS_V2/freertos_os2.h
@@ -1,0 +1,310 @@
+/* --------------------------------------------------------------------------
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *      Name:    freertos_os2.h
+ *      Purpose: CMSIS RTOS2 wrapper for FreeRTOS
+ *
+ *---------------------------------------------------------------------------*/
+
+#ifndef FREERTOS_OS2_H_
+#define FREERTOS_OS2_H_
+
+#include <string.h>
+#include <stdint.h>
+
+#include "FreeRTOS.h"                   // ARM.FreeRTOS::RTOS:Core
+
+#include CMSIS_device_header
+
+/*
+  CMSIS-RTOS2 FreeRTOS image size optimization definitions.
+
+  Note: Definitions configUSE_OS2 can be used to optimize FreeRTOS image size when
+        certain functionality is not required when using CMSIS-RTOS2 API.
+        In general optimization decisions are left to the tool chain but in cases
+        when coding style prevents it to optimize the code following optional
+        definitions can be used.
+*/
+
+/*
+  Option to exclude CMSIS-RTOS2 functions osThreadSuspend and osThreadResume from
+  the application image.
+*/
+#ifndef configUSE_OS2_THREAD_SUSPEND_RESUME
+#define configUSE_OS2_THREAD_SUSPEND_RESUME   1
+#endif
+
+/*
+  Option to exclude CMSIS-RTOS2 function osThreadEnumerate from the application image.
+*/
+#ifndef configUSE_OS2_THREAD_ENUMERATE
+#define configUSE_OS2_THREAD_ENUMERATE        1
+#endif
+
+/*
+  Option to disable CMSIS-RTOS2 function osEventFlagsSet and osEventFlagsClear
+  operation from ISR.
+*/
+#ifndef configUSE_OS2_EVENTFLAGS_FROM_ISR
+#define configUSE_OS2_EVENTFLAGS_FROM_ISR     1
+#endif
+
+/*
+  Option to exclude CMSIS-RTOS2 Thread Flags API functions from the application image.
+*/
+#ifndef configUSE_OS2_THREAD_FLAGS
+#define configUSE_OS2_THREAD_FLAGS            configUSE_TASK_NOTIFICATIONS
+#endif
+
+/*
+  Option to exclude CMSIS-RTOS2 Timer API functions from the application image.
+*/
+#ifndef configUSE_OS2_TIMER
+#define configUSE_OS2_TIMER                   configUSE_TIMERS
+#endif
+
+/*
+  Option to exclude CMSIS-RTOS2 Mutex API functions from the application image.
+*/
+#ifndef configUSE_OS2_MUTEX
+#define configUSE_OS2_MUTEX                   configUSE_MUTEXES
+#endif
+
+
+/*
+  CMSIS-RTOS2 FreeRTOS configuration check (FreeRTOSConfig.h).
+
+  Note: CMSIS-RTOS API requires functions included by using following definitions.
+        In case if certain API function is not used compiler will optimize it away.
+*/
+#if (INCLUDE_xSemaphoreGetMutexHolder == 0)
+  /*
+    CMSIS-RTOS2 function osMutexGetOwner uses FreeRTOS function xSemaphoreGetMutexHolder. In case if
+    osMutexGetOwner is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_xSemaphoreGetMutexHolder 1 to fix this error.
+  */
+  #error "Definition INCLUDE_xSemaphoreGetMutexHolder must equal 1 to implement Mutex Management API."
+#endif
+#if (INCLUDE_vTaskDelay == 0)
+  /*
+    CMSIS-RTOS2 function osDelay uses FreeRTOS function vTaskDelay. In case if
+    osDelay is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_vTaskDelay 1 to fix this error.
+  */
+  #error "Definition INCLUDE_vTaskDelay must equal 1 to implement Generic Wait Functions API."
+#endif
+#if (INCLUDE_vTaskDelayUntil == 0)
+  /*
+    CMSIS-RTOS2 function osDelayUntil uses FreeRTOS function vTaskDelayUntil. In case if
+    osDelayUntil is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_vTaskDelayUntil 1 to fix this error.
+  */
+  #error "Definition INCLUDE_vTaskDelayUntil must equal 1 to implement Generic Wait Functions API."
+#endif
+#if (INCLUDE_vTaskDelete == 0)
+  /*
+    CMSIS-RTOS2 function osThreadTerminate and osThreadExit uses FreeRTOS function
+    vTaskDelete. In case if they are not used in the application image, compiler
+    will optimize them away.
+    Set #define INCLUDE_vTaskDelete 1 to fix this error.
+  */
+  #error "Definition INCLUDE_vTaskDelete must equal 1 to implement Thread Management API."
+#endif
+#if (INCLUDE_xTaskGetCurrentTaskHandle == 0)
+  /*
+    CMSIS-RTOS2 API uses FreeRTOS function xTaskGetCurrentTaskHandle to implement
+    functions osThreadGetId, osThreadFlagsClear and osThreadFlagsGet. In case if these
+    functions are not used in the application image, compiler will optimize them away.
+    Set #define INCLUDE_xTaskGetCurrentTaskHandle 1 to fix this error.
+  */
+  #error "Definition INCLUDE_xTaskGetCurrentTaskHandle must equal 1 to implement Thread Management API."
+#endif
+#if (INCLUDE_xTaskGetSchedulerState == 0)
+  /*
+    CMSIS-RTOS2 API uses FreeRTOS function xTaskGetSchedulerState to implement Kernel
+    tick handling and therefore it is vital that xTaskGetSchedulerState is included into
+    the application image.
+    Set #define INCLUDE_xTaskGetSchedulerState 1 to fix this error.
+  */
+  #error "Definition INCLUDE_xTaskGetSchedulerState must equal 1 to implement Kernel Information and Control API."
+#endif
+#if (INCLUDE_uxTaskGetStackHighWaterMark == 0)
+  /*
+    CMSIS-RTOS2 function osThreadGetStackSpace uses FreeRTOS function uxTaskGetStackHighWaterMark.
+    In case if osThreadGetStackSpace is not used in the application image, compiler will
+    optimize it away.
+    Set #define INCLUDE_uxTaskGetStackHighWaterMark 1 to fix this error.
+  */
+  #error "Definition INCLUDE_uxTaskGetStackHighWaterMark must equal 1 to implement Thread Management API."
+#endif
+#if (INCLUDE_uxTaskPriorityGet == 0)
+  /*
+    CMSIS-RTOS2 function osThreadGetPriority uses FreeRTOS function uxTaskPriorityGet. In case if
+    osThreadGetPriority is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_uxTaskPriorityGet 1 to fix this error.
+  */
+  #error "Definition INCLUDE_uxTaskPriorityGet must equal 1 to implement Thread Management API."
+#endif
+#if (INCLUDE_vTaskPrioritySet == 0)
+  /*
+    CMSIS-RTOS2 function osThreadSetPriority uses FreeRTOS function vTaskPrioritySet. In case if
+    osThreadSetPriority is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_vTaskPrioritySet 1 to fix this error.
+  */
+  #error "Definition INCLUDE_vTaskPrioritySet must equal 1 to implement Thread Management API."
+#endif
+#if (INCLUDE_eTaskGetState == 0)
+  /*
+    CMSIS-RTOS2 API uses FreeRTOS function vTaskDelayUntil to implement functions osThreadGetState
+    and osThreadTerminate. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define INCLUDE_eTaskGetState 1 to fix this error.
+  */
+  #error "Definition INCLUDE_eTaskGetState must equal 1 to implement Thread Management API."
+#endif
+#if (INCLUDE_vTaskSuspend == 0)
+  /*
+    CMSIS-RTOS2 API uses FreeRTOS functions vTaskSuspend and vTaskResume to implement
+    functions osThreadSuspend and osThreadResume. In case if these functions are not
+    used in the application image, compiler will optimize them away.
+    Set #define INCLUDE_vTaskSuspend 1 to fix this error.
+
+    Alternatively, if the application does not use osThreadSuspend and
+    osThreadResume they can be excluded from the image code by setting:
+    #define configUSE_OS2_THREAD_SUSPEND_RESUME 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_THREAD_SUSPEND_RESUME == 1)
+    #error "Definition INCLUDE_vTaskSuspend must equal 1 to implement Kernel Information and Control API."
+  #endif
+#endif
+#if (INCLUDE_xTimerPendFunctionCall == 0)
+  /*
+    CMSIS-RTOS2 function osEventFlagsSet and osEventFlagsClear, when called from
+    the ISR, call FreeRTOS functions xEventGroupSetBitsFromISR and
+    xEventGroupClearBitsFromISR which are only enabled if timers are operational and
+    xTimerPendFunctionCall in enabled.
+    Set #define INCLUDE_xTimerPendFunctionCall 1 and #define configUSE_TIMERS 1
+    to fix this error.
+
+    Alternatively, if the application does not use osEventFlagsSet and osEventFlagsClear
+    from the ISR their operation from ISR can be restricted by setting:
+    #define configUSE_OS2_EVENTFLAGS_FROM_ISR 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_EVENTFLAGS_FROM_ISR == 1)
+    #error "Definition INCLUDE_xTimerPendFunctionCall must equal 1 to implement Event Flags API."
+  #endif
+#endif
+
+#if (configUSE_TIMERS == 0)
+  /*
+    CMSIS-RTOS2 Timer Management API functions use FreeRTOS timer functions to implement
+    timer management. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define configUSE_TIMERS 1 to fix this error.
+
+    Alternatively, if the application does not use timer functions they can be
+    excluded from the image code by setting:
+    #define configUSE_OS2_TIMER 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_TIMER == 1)
+    #error "Definition configUSE_TIMERS must equal 1 to implement Timer Management API."
+  #endif
+#endif
+
+#if (configUSE_MUTEXES == 0)
+  /*
+    CMSIS-RTOS2 Mutex Management API functions use FreeRTOS mutex functions to implement
+    mutex management. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define configUSE_MUTEXES 1 to fix this error.
+
+    Alternatively, if the application does not use mutex functions they can be
+    excluded from the image code by setting:
+    #define configUSE_OS2_MUTEX 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_MUTEX == 1)
+    #error "Definition configUSE_MUTEXES must equal 1 to implement Mutex Management API."
+  #endif
+#endif
+
+#if (configUSE_COUNTING_SEMAPHORES == 0)
+  /*
+    CMSIS-RTOS2 Memory Pool functions use FreeRTOS function xSemaphoreCreateCounting
+    to implement memory pools. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define configUSE_COUNTING_SEMAPHORES 1 to fix this error.
+  */
+  #error "Definition configUSE_COUNTING_SEMAPHORES must equal 1 to implement Memory Pool API."
+#endif
+#if (configUSE_TASK_NOTIFICATIONS == 0)
+  /*
+    CMSIS-RTOS2 Thread Flags API functions use FreeRTOS Task Notification functions to implement
+    thread flag management. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define configUSE_TASK_NOTIFICATIONS 1 to fix this error.
+
+    Alternatively, if the application does not use thread flags functions they can be
+    excluded from the image code by setting:
+    #define configUSE_OS2_THREAD_FLAGS 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_THREAD_FLAGS == 1)
+    #error "Definition configUSE_TASK_NOTIFICATIONS must equal 1 to implement Thread Flags API."
+  #endif
+#endif
+
+#if (configUSE_TRACE_FACILITY == 0)
+  /*
+    CMSIS-RTOS2 function osThreadEnumerate requires FreeRTOS function uxTaskGetSystemState
+    which is only enabled if configUSE_TRACE_FACILITY == 1.
+    Set #define configUSE_TRACE_FACILITY 1 to fix this error.
+
+    Alternatively, if the application does not use osThreadEnumerate it can be
+    excluded from the image code by setting:
+    #define configUSE_OS2_THREAD_ENUMERATE 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_THREAD_ENUMERATE == 1)
+    #error "Definition configUSE_TRACE_FACILITY must equal 1 to implement osThreadEnumerate."
+  #endif
+#endif
+
+#if (configUSE_16_BIT_TICKS == 1)
+  /*
+    CMSIS-RTOS2 wrapper for FreeRTOS relies on 32-bit tick timer which is also optimal on
+    a 32-bit CPU architectures.
+    Set #define configUSE_16_BIT_TICKS 0 to fix this error.
+  */
+  #error "Definition configUSE_16_BIT_TICKS must be zero to implement CMSIS-RTOS2 API."
+#endif
+
+#if (configMAX_PRIORITIES != 56)
+  /*
+    CMSIS-RTOS2 defines 56 different priorities (see osPriority_t) and portable CMSIS-RTOS2
+    implementation should implement the same number of priorities.
+    Set #define configMAX_PRIORITIES 56 to fix this error.
+  */
+  #error "Definition configMAX_PRIORITIES must equal 56 to implement Thread Management API."
+#endif
+#if (configUSE_PORT_OPTIMISED_TASK_SELECTION != 0)
+  /*
+    CMSIS-RTOS2 requires handling of 56 different priorities (see osPriority_t) while FreeRTOS port
+    optimised selection for Cortex core only handles 32 different priorities.
+    Set #define configUSE_PORT_OPTIMISED_TASK_SELECTION 0 to fix this error.
+  */
+  #error "Definition configUSE_PORT_OPTIMISED_TASK_SELECTION must be zero to implement Thread Management API."
+#endif
+
+#endif /* FREERTOS_OS2_H_ */

--- a/portable/Common/mpu_wrappers.c
+++ b/portable/Common/mpu_wrappers.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -365,12 +365,12 @@ BaseType_t xRunningPrivileged = xPortRaisePrivilege();
 /*-----------------------------------------------------------*/
 
 #if( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( INCLUDE_xTaskGetIdleTaskHandle == 1 ) )
-	TickType_t MPU_xTaskGetIdleRunTimeCounter( void ) /* FREERTOS_SYSTEM_CALL */
+	uint32_t MPU_ulTaskGetIdleRunTimeCounter( void ) /* FREERTOS_SYSTEM_CALL */
 	{
-	TickType_t xReturn;
+	uint32_t xReturn;
 	BaseType_t xRunningPrivileged = xPortRaisePrivilege();
 
-		xReturn = xTaskGetIdleRunTimeCounter();
+		xReturn = ulTaskGetIdleRunTimeCounter();
 		vPortResetPrivilege( xRunningPrivileged );
 		return xReturn;
 	}
@@ -449,6 +449,17 @@ BaseType_t xRunningPrivileged = xPortRaisePrivilege();
 		return uxReturn;
 	}
 #endif
+/*-----------------------------------------------------------*/
+
+BaseType_t MPU_xTaskCatchUpTicks( TickType_t xTicksToCatchUp ) /* FREERTOS_SYSTEM_CALL */
+{
+BaseType_t xReturn;
+BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+
+	xReturn = xTaskCatchUpTicks( xTicksToCatchUp );
+	vPortResetPrivilege( xRunningPrivileged );
+	return xReturn;
+}
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
@@ -571,6 +582,19 @@ BaseType_t xRunningPrivileged = xPortRaisePrivilege();
 		xReturn = xTaskNotifyStateClear( xTask );
 		vPortResetPrivilege( xRunningPrivileged );
 		return xReturn;
+	}
+#endif
+/*-----------------------------------------------------------*/
+
+#if( configUSE_TASK_NOTIFICATIONS == 1 )
+	uint32_t MPU_ulTaskNotifyValueClear( TaskHandle_t xTask, uint32_t ulBitsToClear ) /* FREERTOS_SYSTEM_CALL */
+	{
+	uint32_t ulReturn;
+	BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+
+		ulReturn = ulTaskNotifyValueClear( xTask, ulBitsToClear );
+		vPortResetPrivilege( xRunningPrivileged );
+		return ulReturn;
 	}
 #endif
 /*-----------------------------------------------------------*/
@@ -1026,6 +1050,19 @@ BaseType_t xRunningPrivileged = xPortRaisePrivilege();
 
 		vTimerSetReloadMode( xTimer, uxAutoReload );
 		vPortResetPrivilege( xRunningPrivileged );
+	}
+#endif
+/*-----------------------------------------------------------*/
+
+#if( configUSE_TIMERS == 1 )
+	UBaseType_t MPU_uxTimerGetReloadMode( TimerHandle_t xTimer )
+	{
+	BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+	UBaseType_t uxReturn;
+
+		uxReturn = uxTimerGetReloadMode( xTimer );
+		vPortResetPrivilege( xRunningPrivileged );
+		return uxReturn;
 	}
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM0/port.c
+++ b/portable/GCC/ARM_CM0/port.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -33,21 +33,17 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
-#ifndef configSYSTICK_CLOCK_HZ
-	#define configSYSTICK_CLOCK_HZ configCPU_CLOCK_HZ
-#endif
-
 /* Constants required to manipulate the NVIC. */
-#define portNVIC_SYSTICK_CTRL		(* ( ( volatile uint32_t *) 0xe000e010 ) )
-#define portNVIC_SYSTICK_LOAD		(* ( ( volatile uint32_t *) 0xe000e014 ) )
-#define portNVIC_SYSTICK_CURRENT_VALUE	(* ( ( volatile uint32_t * ) 0xe000e018 ))
-#define portNVIC_INT_CTRL				( ( volatile uint32_t *) 0xe000ed04 )
-#define portNVIC_SYSPRI2				( ( volatile uint32_t *) 0xe000ed20 )
-#define portNVIC_SYSTICK_CLK			0x00000004
-#define portNVIC_SYSTICK_INT			0x00000002
-#define portNVIC_SYSTICK_ENABLE			0x00000001
-#define portNVIC_SYSTICK_COUNT_FLAG	( 1UL << 16UL )
-#define portNVIC_PENDSVSET				0x10000000
+#define portNVIC_SYSTICK_CTRL_REG			( * ( ( volatile uint32_t * ) 0xe000e010 ) )
+#define portNVIC_SYSTICK_LOAD_REG			( * ( ( volatile uint32_t * ) 0xe000e014 ) )
+#define portNVIC_SYSTICK_CURRENT_VALUE_REG	( * ( ( volatile uint32_t * ) 0xe000e018 ) )
+#define portNVIC_INT_CTRL_REG				( * ( ( volatile uint32_t * ) 0xe000ed04 ) )
+#define portNVIC_SYSPRI2_REG				( * ( ( volatile uint32_t * ) 0xe000ed20 ) )
+#define portNVIC_SYSTICK_CLK_BIT			( 1UL << 2UL )
+#define portNVIC_SYSTICK_INT_BIT			( 1UL << 1UL )
+#define portNVIC_SYSTICK_ENABLE_BIT			( 1UL << 0UL )
+#define portNVIC_SYSTICK_COUNT_FLAG_BIT		( 1UL << 16UL )
+#define portNVIC_PENDSVSET_BIT				( 1UL << 28UL )
 #define portMIN_INTERRUPT_PRIORITY		( 255UL )
 #define portNVIC_PENDSV_PRI				( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI			( portMIN_INTERRUPT_PRIORITY << 24UL )
@@ -61,7 +57,9 @@
 /* A fiddle factor to estimate the number of SysTick counts that would have
 occurred while the SysTick counter is stopped during tickless idle
 calculations. */
-#define portMISSED_COUNTS_FACTOR			( 45UL )
+#ifndef portMISSED_COUNTS_FACTOR
+	#define portMISSED_COUNTS_FACTOR			( 45UL )
+#endif
 
 /* Let the user override the pre-loading of the initial LR with the address of
 prvTaskExitError() in case it messes up unwinding of the stack in the
@@ -73,9 +71,11 @@ debugger. */
 #endif
 
 /*
- * Setup the timer to generate the tick interrupts.
+ * Setup the timer to generate the tick interrupts.  The implementation in this
+ * file is weak to allow application writers to change the timer used to
+ * generate the tick interrupt.
  */
-static void prvSetupTimerInterrupt( void );
+void vPortSetupTimerInterrupt( void );
 
 /*
  * Exception handlers.
@@ -103,26 +103,26 @@ static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
 /*-----------------------------------------------------------*/
 
 /*
- * The number of SysTick increments that make up one tick period.
- */
-#if configUSE_TICKLESS_IDLE == 1
-	static unsigned long ulTimerCountsForOneTick = 0;
+* The number of SysTick increments that make up one tick period.
+*/
+#if( configUSE_TICKLESS_IDLE == 1 )
+	static uint32_t ulTimerCountsForOneTick = 0;
 #endif /* configUSE_TICKLESS_IDLE */
 
 /*
  * The maximum number of tick periods that can be suppressed is limited by the
  * 24 bit resolution of the SysTick timer.
  */
-#if configUSE_TICKLESS_IDLE == 1
-	static unsigned long xMaximumPossibleSuppressedTicks = 0;
+#if( configUSE_TICKLESS_IDLE == 1 )
+	static uint32_t xMaximumPossibleSuppressedTicks = 0;
 #endif /* configUSE_TICKLESS_IDLE */
 
 /*
  * Compensate for the CPU cycles that pass while the SysTick is stopped (low
  * power functionality only.
  */
-#if configUSE_TICKLESS_IDLE == 1
-	static unsigned long ulStoppedTimerCompensation = 0;
+#if( configUSE_TICKLESS_IDLE == 1 )
+	static uint32_t ulStoppedTimerCompensation = 0;
 #endif /* configUSE_TICKLESS_IDLE */
 
 /*-----------------------------------------------------------*/
@@ -214,12 +214,12 @@ void vPortStartFirstTask( void )
 BaseType_t xPortStartScheduler( void )
 {
 	/* Make PendSV, CallSV and SysTick the same priority as the kernel. */
-	*(portNVIC_SYSPRI2) |= portNVIC_PENDSV_PRI;
-	*(portNVIC_SYSPRI2) |= portNVIC_SYSTICK_PRI;
+	portNVIC_SYSPRI2_REG |= portNVIC_PENDSV_PRI;
+	portNVIC_SYSPRI2_REG |= portNVIC_SYSTICK_PRI;
 
 	/* Start the timer that generates the tick ISR.  Interrupts are disabled
 	here already. */
-	prvSetupTimerInterrupt();
+	vPortSetupTimerInterrupt();
 
 	/* Initialise the critical nesting count ready for the first task. */
 	uxCriticalNesting = 0;
@@ -252,7 +252,7 @@ void vPortEndScheduler( void )
 void vPortYield( void )
 {
 	/* Set a PendSV to request a context switch. */
-	*( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET;
+	portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
 
 	/* Barriers are normally not required but do ensure the code is completely
 	within the specified behaviour for the architecture. */
@@ -263,8 +263,8 @@ void vPortYield( void )
 
 void vPortEnterCritical( void )
 {
-    portDISABLE_INTERRUPTS();
-    uxCriticalNesting++;
+	portDISABLE_INTERRUPTS();
+	uxCriticalNesting++;
 	__asm volatile( "dsb" ::: "memory" );
 	__asm volatile( "isb" );
 }
@@ -273,11 +273,11 @@ void vPortEnterCritical( void )
 void vPortExitCritical( void )
 {
 	configASSERT( uxCriticalNesting );
-    uxCriticalNesting--;
-    if( uxCriticalNesting == 0 )
-    {
-        portENABLE_INTERRUPTS();
-    }
+	uxCriticalNesting--;
+	if( uxCriticalNesting == 0 )
+	{
+		portENABLE_INTERRUPTS();
+	}
 }
 /*-----------------------------------------------------------*/
 
@@ -289,13 +289,6 @@ uint32_t ulSetInterruptMaskFromISR( void )
 					" bx lr				  "
 					::: "memory"
 				  );
-
-#if !defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-	/* To avoid compiler warnings.  The return statement will nevere be reached,
-	but some compilers warn if it is not included, while others won't compile if
-	it is. */
-	return 0;
-#endif
 }
 /*-----------------------------------------------------------*/
 
@@ -306,13 +299,6 @@ void vClearInterruptMaskFromISR( __attribute__( ( unused ) ) uint32_t ulMask )
 					" bx lr				  "
 					::: "memory"
 				  );
-
-#if !defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-	/* Just to avoid compiler warning.  ulMask is used from the asm code but
-	the compiler can't see that.  Some compilers generate warnings without the
-	following line, while others generate warnings if the line is included. */
-	( void ) ulMask;
-#endif
 }
 /*-----------------------------------------------------------*/
 
@@ -375,18 +361,43 @@ uint32_t ulPreviousMask;
 		if( xTaskIncrementTick() != pdFALSE )
 		{
 			/* Pend a context switch. */
-			*(portNVIC_INT_CTRL) = portNVIC_PENDSVSET;
+			portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
 		}
 	}
 	portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );
 }
 /*-----------------------------------------------------------*/
 
-#if configUSE_TICKLESS_IDLE == 1
+/*
+ * Setup the systick timer to generate the tick interrupts at the required
+ * frequency.
+ */
+__attribute__(( weak )) void vPortSetupTimerInterrupt( void )
+{
+	/* Calculate the constants required to configure the tick interrupt. */
+	#if( configUSE_TICKLESS_IDLE == 1 )
+	{
+		ulTimerCountsForOneTick = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ );
+		xMaximumPossibleSuppressedTicks = portMAX_24_BIT_NUMBER / ulTimerCountsForOneTick;
+		ulStoppedTimerCompensation = portMISSED_COUNTS_FACTOR;
+	}
+	#endif /* configUSE_TICKLESS_IDLE */
+
+	/* Stop and reset the SysTick. */
+	portNVIC_SYSTICK_CTRL_REG = 0UL;
+	portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+
+	/* Configure SysTick to interrupt at the requested rate. */
+	portNVIC_SYSTICK_LOAD_REG = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
+	portNVIC_SYSTICK_CTRL_REG = portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT | portNVIC_SYSTICK_ENABLE_BIT;
+}
+/*-----------------------------------------------------------*/
+
+#if( configUSE_TICKLESS_IDLE == 1 )
 
 	__attribute__((weak)) void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime )
 	{
-	uint32_t ulReloadValue, ulCompleteTickPeriods, ulCompletedSysTickDecrements, ulSysTickCTRL;
+	uint32_t ulReloadValue, ulCompleteTickPeriods, ulCompletedSysTickDecrements;
 	TickType_t xModifiableIdleTime;
 
 		/* Make sure the SysTick reload value does not overflow the counter. */
@@ -399,12 +410,12 @@ uint32_t ulPreviousMask;
 		is accounted for as best it can be, but using the tickless mode will
 		inevitably result in some tiny drift of the time maintained by the
 		kernel with respect to calendar time. */
-		portNVIC_SYSTICK_CTRL &= ~portNVIC_SYSTICK_ENABLE;
+		portNVIC_SYSTICK_CTRL_REG &= ~portNVIC_SYSTICK_ENABLE_BIT;
 
 		/* Calculate the reload value required to wait xExpectedIdleTime
 		tick periods.  -1 is used because this code will execute part way
 		through one of the tick periods. */
-		ulReloadValue = portNVIC_SYSTICK_CURRENT_VALUE + ( ulTimerCountsForOneTick * ( xExpectedIdleTime - 1UL ) );
+		ulReloadValue = portNVIC_SYSTICK_CURRENT_VALUE_REG + ( ulTimerCountsForOneTick * ( xExpectedIdleTime - 1UL ) );
 		if( ulReloadValue > ulStoppedTimerCompensation )
 		{
 			ulReloadValue -= ulStoppedTimerCompensation;
@@ -412,7 +423,9 @@ uint32_t ulPreviousMask;
 
 		/* Enter a critical section but don't use the taskENTER_CRITICAL()
 		method as that will mask interrupts that should exit sleep mode. */
-		__asm volatile( "cpsid i" );
+		__asm volatile( "cpsid i" ::: "memory" );
+		__asm volatile( "dsb" );
+		__asm volatile( "isb" );
 
 		/* If a context switch is pending or a task is waiting for the scheduler
 		to be unsuspended then abandon the low power entry. */
@@ -420,30 +433,30 @@ uint32_t ulPreviousMask;
 		{
 			/* Restart from whatever is left in the count register to complete
 			this tick period. */
-			portNVIC_SYSTICK_LOAD = portNVIC_SYSTICK_CURRENT_VALUE;
+			portNVIC_SYSTICK_LOAD_REG = portNVIC_SYSTICK_CURRENT_VALUE_REG;
 
 			/* Restart SysTick. */
-			portNVIC_SYSTICK_CTRL |= portNVIC_SYSTICK_ENABLE;
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
 
 			/* Reset the reload register to the value required for normal tick
 			periods. */
-			portNVIC_SYSTICK_LOAD = ulTimerCountsForOneTick - 1UL;
+			portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
 
 			/* Re-enable interrupts - see comments above the cpsid instruction()
 			above. */
-			__asm volatile( "cpsie i" );
+			__asm volatile( "cpsie i" ::: "memory" );
 		}
 		else
 		{
 			/* Set the new reload value. */
-			portNVIC_SYSTICK_LOAD = ulReloadValue;
+			portNVIC_SYSTICK_LOAD_REG = ulReloadValue;
 
 			/* Clear the SysTick count flag and set the count value back to
 			zero. */
-			portNVIC_SYSTICK_CURRENT_VALUE = 0UL;
+			portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
 
 			/* Restart SysTick. */
-			portNVIC_SYSTICK_CTRL |= portNVIC_SYSTICK_ENABLE;
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
 
 			/* Sleep until something happens.  configPRE_SLEEP_PROCESSING() can
 			set its parameter to 0 to indicate that its implementation contains
@@ -451,35 +464,53 @@ uint32_t ulPreviousMask;
 			should not be executed again.  However, the original expected idle
 			time variable must remain unmodified, so a copy is taken. */
 			xModifiableIdleTime = xExpectedIdleTime;
-			configPRE_SLEEP_PROCESSING( &xModifiableIdleTime );
+			configPRE_SLEEP_PROCESSING( xModifiableIdleTime );
 			if( xModifiableIdleTime > 0 )
 			{
-				__asm volatile( "dsb" );
+				__asm volatile( "dsb" ::: "memory" );
 				__asm volatile( "wfi" );
 				__asm volatile( "isb" );
 			}
-			configPOST_SLEEP_PROCESSING( &xExpectedIdleTime );
+			configPOST_SLEEP_PROCESSING( xExpectedIdleTime );
 
-			/* Stop SysTick.  Again, the time the SysTick is stopped for is
-			accounted for as best it can be, but using the tickless mode will
-			inevitably result in some tiny drift of the time maintained by the
-			kernel with respect to calendar time. */
-			ulSysTickCTRL = portNVIC_SYSTICK_CTRL;
-			portNVIC_SYSTICK_CTRL = ( ulSysTickCTRL & ~portNVIC_SYSTICK_ENABLE );
+			/* Re-enable interrupts to allow the interrupt that brought the MCU
+			out of sleep mode to execute immediately.  see comments above
+			__disable_interrupt() call above. */
+			__asm volatile( "cpsie i" ::: "memory" );
+			__asm volatile( "dsb" );
+			__asm volatile( "isb" );
 
-			/* Re-enable interrupts - see comments above the cpsid instruction()
-			above. */
-			__asm volatile( "cpsie i" );
+			/* Disable interrupts again because the clock is about to be stopped
+			and interrupts that execute while the clock is stopped will increase
+			any slippage between the time maintained by the RTOS and calendar
+			time. */
+			__asm volatile( "cpsid i" ::: "memory" );
+			__asm volatile( "dsb" );
+			__asm volatile( "isb" );
 
-			if( ( ulSysTickCTRL & portNVIC_SYSTICK_COUNT_FLAG ) != 0 )
+			/* Disable the SysTick clock without reading the
+			portNVIC_SYSTICK_CTRL_REG register to ensure the
+			portNVIC_SYSTICK_COUNT_FLAG_BIT is not cleared if it is set.  Again,
+			the time the SysTick is stopped for is accounted for as best it can
+			be, but using the tickless mode will inevitably result in some tiny
+			drift of the time maintained by the kernel with respect to calendar
+			time*/
+			portNVIC_SYSTICK_CTRL_REG = ( portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT );
+
+			/* Determine if the SysTick clock has already counted to zero and
+			been set back to the current reload value (the reload back being
+			correct for the entire expected idle time) or if the SysTick is yet
+			to count to zero (in which case an interrupt other than the SysTick
+			must have brought the system out of sleep mode). */
+			if( ( portNVIC_SYSTICK_CTRL_REG & portNVIC_SYSTICK_COUNT_FLAG_BIT ) != 0 )
 			{
 				uint32_t ulCalculatedLoadValue;
 
-				/* The tick interrupt has already executed, and the SysTick
-				count reloaded with ulReloadValue.  Reset the
-				portNVIC_SYSTICK_LOAD with whatever remains of this tick
+				/* The tick interrupt is already pending, and the SysTick count
+				reloaded with ulReloadValue.  Reset the
+				portNVIC_SYSTICK_LOAD_REG with whatever remains of this tick
 				period. */
-				ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL ) - ( ulReloadValue - portNVIC_SYSTICK_CURRENT_VALUE );
+				ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL ) - ( ulReloadValue - portNVIC_SYSTICK_CURRENT_VALUE_REG );
 
 				/* Don't allow a tiny value, or values that have somehow
 				underflowed because the post sleep hook did something
@@ -489,13 +520,11 @@ uint32_t ulPreviousMask;
 					ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL );
 				}
 
-				portNVIC_SYSTICK_LOAD = ulCalculatedLoadValue;
+				portNVIC_SYSTICK_LOAD_REG = ulCalculatedLoadValue;
 
-				/* The tick interrupt handler will already have pended the tick
-				processing in the kernel.  As the pending tick will be
-				processed as soon as this function exits, the tick value
-				maintained by the tick is stepped forward by one less than the
-				time spent waiting. */
+				/* As the pending tick will be processed as soon as this
+				function exits, the tick value maintained by the tick is stepped
+				forward by one less than the time spent waiting. */
 				ulCompleteTickPeriods = xExpectedIdleTime - 1UL;
 			}
 			else
@@ -504,7 +533,7 @@ uint32_t ulPreviousMask;
 				Work out how long the sleep lasted rounded to complete tick
 				periods (not the ulReload value which accounted for part
 				ticks). */
-				ulCompletedSysTickDecrements = ( xExpectedIdleTime * ulTimerCountsForOneTick ) - portNVIC_SYSTICK_CURRENT_VALUE;
+				ulCompletedSysTickDecrements = ( xExpectedIdleTime * ulTimerCountsForOneTick ) - portNVIC_SYSTICK_CURRENT_VALUE_REG;
 
 				/* How many complete tick periods passed while the processor
 				was waiting? */
@@ -512,50 +541,20 @@ uint32_t ulPreviousMask;
 
 				/* The reload value is set to whatever fraction of a single tick
 				period remains. */
-				portNVIC_SYSTICK_LOAD = ( ( ulCompleteTickPeriods + 1 ) * ulTimerCountsForOneTick ) - ulCompletedSysTickDecrements;
+				portNVIC_SYSTICK_LOAD_REG = ( ( ulCompleteTickPeriods + 1UL ) * ulTimerCountsForOneTick ) - ulCompletedSysTickDecrements;
 			}
 
-			/* Restart SysTick so it runs from portNVIC_SYSTICK_LOAD
-			again, then set portNVIC_SYSTICK_LOAD back to its standard
-			value.  The critical section is used to ensure the tick interrupt
-			can only execute once in the case that the reload register is near
-			zero. */
-			portNVIC_SYSTICK_CURRENT_VALUE = 0UL;
-			portENTER_CRITICAL();
-			{
-				portNVIC_SYSTICK_CTRL |= portNVIC_SYSTICK_ENABLE;
-				vTaskStepTick( ulCompleteTickPeriods );
-				portNVIC_SYSTICK_LOAD = ulTimerCountsForOneTick - 1UL;
-			}
-			portEXIT_CRITICAL();
+			/* Restart SysTick so it runs from portNVIC_SYSTICK_LOAD_REG
+			again, then set portNVIC_SYSTICK_LOAD_REG back to its standard
+			value. */
+			portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+			vTaskStepTick( ulCompleteTickPeriods );
+			portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
+
+			/* Exit with interrpts enabled. */
+			__asm volatile( "cpsie i" ::: "memory" );
 		}
 	}
 
-#endif /* #if configUSE_TICKLESS_IDLE */
-/*-----------------------------------------------------------*/
-
-/*
- * Setup the systick timer to generate the tick interrupts at the required
- * frequency.
- */
-void prvSetupTimerInterrupt( void )
-{
- /* Calculate the constants required to configure the tick interrupt. */
- #if configUSE_TICKLESS_IDLE == 1
- {
-   ulTimerCountsForOneTick = ( configSYSTICK_CLOCK_HZ / configTICK_RATE_HZ );
-   xMaximumPossibleSuppressedTicks = portMAX_24_BIT_NUMBER / ulTimerCountsForOneTick;
-   ulStoppedTimerCompensation = portMISSED_COUNTS_FACTOR / ( configCPU_CLOCK_HZ / configSYSTICK_CLOCK_HZ );
- }
- #endif /* configUSE_TICKLESS_IDLE */
-
-/* Stop and reset the SysTick. */
-	portNVIC_SYSTICK_CTRL = 0UL;
-	portNVIC_SYSTICK_CURRENT_VALUE = 0UL;
-
- /* Configure SysTick to interrupt at the requested rate. */
- portNVIC_SYSTICK_LOAD = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
- portNVIC_SYSTICK_CTRL = portNVIC_SYSTICK_CLK | portNVIC_SYSTICK_INT | portNVIC_SYSTICK_ENABLE;
-}
-/*-----------------------------------------------------------*/
-
+#endif /* configUSE_TICKLESS_IDLE */

--- a/portable/GCC/ARM_CM0/portmacro.h
+++ b/portable/GCC/ARM_CM0/portmacro.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -106,7 +106,6 @@ extern void vClearInterruptMaskFromISR( uint32_t ulMask )  __attribute__((naked)
 	extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
 	#define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime ) vPortSuppressTicksAndSleep( xExpectedIdleTime )
 #endif
-
 /*-----------------------------------------------------------*/
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -71,25 +71,32 @@
 /**
  * @brief Constants required to manipulate the NVIC.
  */
-#define portNVIC_SYSTICK_CTRL				( ( volatile uint32_t * ) 0xe000e010 )
-#define portNVIC_SYSTICK_LOAD				( ( volatile uint32_t * ) 0xe000e014 )
-#define portNVIC_SYSTICK_CURRENT_VALUE		( ( volatile uint32_t * ) 0xe000e018 )
-#define portNVIC_INT_CTRL					( ( volatile uint32_t * ) 0xe000ed04 )
-#define portNVIC_SYSPRI2					( ( volatile uint32_t * ) 0xe000ed20 )
-#define portNVIC_SYSTICK_CLK				( 0x00000004 )
-#define portNVIC_SYSTICK_INT				( 0x00000002 )
-#define portNVIC_SYSTICK_ENABLE				( 0x00000001 )
-#define portNVIC_PENDSVSET					( 0x10000000 )
+#define portNVIC_SYSTICK_CTRL_REG			( * ( ( volatile uint32_t * ) 0xe000e010 ) )
+#define portNVIC_SYSTICK_LOAD_REG			( * ( ( volatile uint32_t * ) 0xe000e014 ) )
+#define portNVIC_SYSTICK_CURRENT_VALUE_REG	( * ( ( volatile uint32_t * ) 0xe000e018 ) )
+#define portNVIC_SYSPRI2_REG				( * ( ( volatile uint32_t * ) 0xe000ed20 ) )
+#define portNVIC_SYSTICK_ENABLE_BIT			( 1UL << 0UL )
+#define portNVIC_SYSTICK_INT_BIT			( 1UL << 1UL )
+#define portNVIC_SYSTICK_COUNT_FLAG_BIT		( 1UL << 16UL )
 #define portMIN_INTERRUPT_PRIORITY			( 255UL )
 #define portNVIC_PENDSV_PRI					( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI				( portMIN_INTERRUPT_PRIORITY << 24UL )
+#ifndef configSYSTICK_CLOCK_HZ
+	#define configSYSTICK_CLOCK_HZ			configCPU_CLOCK_HZ
+	/* Ensure the SysTick is clocked at the same frequency as the core. */
+	#define portNVIC_SYSTICK_CLK_BIT		( 1UL << 2UL )
+#else
+	/* The way the SysTick is clocked is not modified in case it is not the
+	 * same a the core. */
+	#define portNVIC_SYSTICK_CLK_BIT		( 0 )
+#endif
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Constants required to manipulate the SCB.
  */
 #define portSCB_SYS_HANDLER_CTRL_STATE_REG	( * ( volatile uint32_t * ) 0xe000ed24 )
-#define portSCB_MEM_FAULT_ENABLE			( 1UL << 16UL )
+#define portSCB_MEM_FAULT_ENABLE_BIT		( 1UL << 16UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -169,13 +176,28 @@
 #define portMPU_RLAR_REGION_ENABLE			( 1UL )
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE		( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT	( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE						( 1UL << 0UL )
+#define portMPU_ENABLE_BIT					( 1UL << 0UL )
 
 /* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE			( 8UL << 8UL ) /* 8 regions, unified. */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The maximum 24-bit number.
+ *
+ * It is needed because the systick is a 24-bit counter.
+ */
+#define portMAX_24_BIT_NUMBER				( 0xffffffUL )
+
+/**
+ * @brief A fiddle factor to estimate the number of SysTick counts that would
+ * have occurred while the SysTick counter is stopped during tickless idle
+ * calculations.
+ */
+#define portMISSED_COUNTS_FACTOR			( 45UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -258,11 +280,6 @@
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Setup the timer to generate the tick interrupts.
- */
-static void prvSetupTimerInterrupt( void ) PRIVILEGED_FUNCTION;
-
-/**
  * @brief Used to catch tasks that attempt to return from their implementing
  * function.
  */
@@ -281,6 +298,22 @@ static void prvTaskExitError( void );
 	 */
 	static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
+
+/**
+ * @brief Setup the timer to generate the tick interrupts.
+ *
+ * The implementation in this file is weak to allow application writers to
+ * change the timer used to generate the tick interrupt.
+ */
+void vPortSetupTimerInterrupt( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Checks whether the current execution context is interrupt.
+ *
+ * @return pdTRUE if the current execution context is interrupt, pdFALSE
+ * otherwise.
+ */
+BaseType_t xPortIsInsideInterrupt( void );
 
 /**
  * @brief Yield the processor.
@@ -321,17 +354,211 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 	 */
 	portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
 #endif /* configENABLE_TRUSTZONE */
+
+#if( configUSE_TICKLESS_IDLE == 1 )
+	/**
+	 * @brief The number of SysTick increments that make up one tick period.
+	 */
+	static uint32_t ulTimerCountsForOneTick = 0;
+
+	/**
+	 * @brief The maximum number of tick periods that can be suppressed is
+	 * limited by the 24 bit resolution of the SysTick timer.
+	 */
+	static uint32_t xMaximumPossibleSuppressedTicks = 0;
+
+	/**
+	 * @brief Compensate for the CPU cycles that pass while the SysTick is
+	 * stopped (low power functionality only).
+	 */
+	static uint32_t ulStoppedTimerCompensation = 0;
+#endif /* configUSE_TICKLESS_IDLE */
 /*-----------------------------------------------------------*/
 
-static void prvSetupTimerInterrupt( void ) /* PRIVILEGED_FUNCTION */
+#if( configUSE_TICKLESS_IDLE == 1 )
+	__attribute__(( weak )) void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime )
+	{
+	uint32_t ulReloadValue, ulCompleteTickPeriods, ulCompletedSysTickDecrements;
+	TickType_t xModifiableIdleTime;
+
+		/* Make sure the SysTick reload value does not overflow the counter. */
+		if( xExpectedIdleTime > xMaximumPossibleSuppressedTicks )
+		{
+			xExpectedIdleTime = xMaximumPossibleSuppressedTicks;
+		}
+
+		/* Stop the SysTick momentarily. The time the SysTick is stopped for is
+		 * accounted for as best it can be, but using the tickless mode will
+		 * inevitably result in some tiny drift of the time maintained by the
+		 * kernel with respect to calendar time. */
+		portNVIC_SYSTICK_CTRL_REG &= ~portNVIC_SYSTICK_ENABLE_BIT;
+
+		/* Calculate the reload value required to wait xExpectedIdleTime
+		 * tick periods. -1 is used because this code will execute part way
+		 * through one of the tick periods. */
+		ulReloadValue = portNVIC_SYSTICK_CURRENT_VALUE_REG + ( ulTimerCountsForOneTick * ( xExpectedIdleTime - 1UL ) );
+		if( ulReloadValue > ulStoppedTimerCompensation )
+		{
+			ulReloadValue -= ulStoppedTimerCompensation;
+		}
+
+		/* Enter a critical section but don't use the taskENTER_CRITICAL()
+		 * method as that will mask interrupts that should exit sleep mode. */
+		__asm volatile( "cpsid i" ::: "memory" );
+		__asm volatile( "dsb" );
+		__asm volatile( "isb" );
+
+		/* If a context switch is pending or a task is waiting for the scheduler
+		 * to be un-suspended then abandon the low power entry. */
+		if( eTaskConfirmSleepModeStatus() == eAbortSleep )
+		{
+			/* Restart from whatever is left in the count register to complete
+			 * this tick period. */
+			portNVIC_SYSTICK_LOAD_REG = portNVIC_SYSTICK_CURRENT_VALUE_REG;
+
+			/* Restart SysTick. */
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+
+			/* Reset the reload register to the value required for normal tick
+			 * periods. */
+			portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
+
+			/* Re-enable interrupts - see comments above the cpsid instruction()
+			 * above. */
+			__asm volatile( "cpsie i" ::: "memory" );
+		}
+		else
+		{
+			/* Set the new reload value. */
+			portNVIC_SYSTICK_LOAD_REG = ulReloadValue;
+
+			/* Clear the SysTick count flag and set the count value back to
+			 * zero. */
+			portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+
+			/* Restart SysTick. */
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+
+			/* Sleep until something happens. configPRE_SLEEP_PROCESSING() can
+			 * set its parameter to 0 to indicate that its implementation
+			 * contains its own wait for interrupt or wait for event
+			 * instruction, and so wfi should not be executed again. However,
+			 * the original expected idle time variable must remain unmodified,
+			 * so a copy is taken. */
+			xModifiableIdleTime = xExpectedIdleTime;
+			configPRE_SLEEP_PROCESSING( xModifiableIdleTime );
+			if( xModifiableIdleTime > 0 )
+			{
+				__asm volatile( "dsb" ::: "memory" );
+				__asm volatile( "wfi" );
+				__asm volatile( "isb" );
+			}
+			configPOST_SLEEP_PROCESSING( xExpectedIdleTime );
+
+			/* Re-enable interrupts to allow the interrupt that brought the MCU
+			 * out of sleep mode to execute immediately. See comments above
+			 * the cpsid instruction above. */
+			__asm volatile( "cpsie i" ::: "memory" );
+			__asm volatile( "dsb" );
+			__asm volatile( "isb" );
+
+			/* Disable interrupts again because the clock is about to be stopped
+			 * and interrupts that execute while the clock is stopped will
+			 * increase any slippage between the time maintained by the RTOS and
+			 * calendar time. */
+			__asm volatile( "cpsid i" ::: "memory" );
+			__asm volatile( "dsb" );
+			__asm volatile( "isb" );
+
+			/* Disable the SysTick clock without reading the
+			 * portNVIC_SYSTICK_CTRL_REG register to ensure the
+			 * portNVIC_SYSTICK_COUNT_FLAG_BIT is not cleared if it is set.
+			 * Again, the time the SysTick is stopped for is accounted for as
+			 * best it can be, but using the tickless mode will inevitably
+			 * result in some tiny drift of the time maintained by the kernel
+			 * with respect to calendar time*/
+			portNVIC_SYSTICK_CTRL_REG = ( portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT );
+
+			/* Determine if the SysTick clock has already counted to zero and
+			 * been set back to the current reload value (the reload back being
+			 * correct for the entire expected idle time) or if the SysTick is
+			 * yet to count to zero (in which case an interrupt other than the
+			 * SysTick must have brought the system out of sleep mode). */
+			if( ( portNVIC_SYSTICK_CTRL_REG & portNVIC_SYSTICK_COUNT_FLAG_BIT ) != 0 )
+			{
+				uint32_t ulCalculatedLoadValue;
+
+				/* The tick interrupt is already pending, and the SysTick count
+				 * reloaded with ulReloadValue.  Reset the
+				 * portNVIC_SYSTICK_LOAD_REG with whatever remains of this tick
+				 * period. */
+				ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL ) - ( ulReloadValue - portNVIC_SYSTICK_CURRENT_VALUE_REG );
+
+				/* Don't allow a tiny value, or values that have somehow
+				 * underflowed because the post sleep hook did something
+				 * that took too long. */
+				if( ( ulCalculatedLoadValue < ulStoppedTimerCompensation ) || ( ulCalculatedLoadValue > ulTimerCountsForOneTick ) )
+				{
+					ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL );
+				}
+
+				portNVIC_SYSTICK_LOAD_REG = ulCalculatedLoadValue;
+
+				/* As the pending tick will be processed as soon as this
+				 * function exits, the tick value maintained by the tick is
+				 * stepped forward by one less than the time spent waiting. */
+				ulCompleteTickPeriods = xExpectedIdleTime - 1UL;
+			}
+			else
+			{
+				/* Something other than the tick interrupt ended the sleep.
+				 * Work out how long the sleep lasted rounded to complete tick
+				 * periods (not the ulReload value which accounted for part
+				 * ticks). */
+				ulCompletedSysTickDecrements = ( xExpectedIdleTime * ulTimerCountsForOneTick ) - portNVIC_SYSTICK_CURRENT_VALUE_REG;
+
+				/* How many complete tick periods passed while the processor
+				 * was waiting? */
+				ulCompleteTickPeriods = ulCompletedSysTickDecrements / ulTimerCountsForOneTick;
+
+				/* The reload value is set to whatever fraction of a single tick
+				 * period remains. */
+				portNVIC_SYSTICK_LOAD_REG = ( ( ulCompleteTickPeriods + 1UL ) * ulTimerCountsForOneTick ) - ulCompletedSysTickDecrements;
+			}
+
+			/* Restart SysTick so it runs from portNVIC_SYSTICK_LOAD_REG
+			 * again, then set portNVIC_SYSTICK_LOAD_REG back to its standard
+			 * value. */
+			portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+			vTaskStepTick( ulCompleteTickPeriods );
+			portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
+
+			/* Exit with interrupts enabled. */
+			__asm volatile( "cpsie i" ::: "memory" );
+		}
+	}
+#endif /* configUSE_TICKLESS_IDLE */
+/*-----------------------------------------------------------*/
+
+__attribute__(( weak )) void vPortSetupTimerInterrupt( void ) /* PRIVILEGED_FUNCTION */
 {
+	/* Calculate the constants required to configure the tick interrupt. */
+	#if( configUSE_TICKLESS_IDLE == 1 )
+	{
+		ulTimerCountsForOneTick = ( configSYSTICK_CLOCK_HZ / configTICK_RATE_HZ );
+		xMaximumPossibleSuppressedTicks = portMAX_24_BIT_NUMBER / ulTimerCountsForOneTick;
+		ulStoppedTimerCompensation = portMISSED_COUNTS_FACTOR / ( configCPU_CLOCK_HZ / configSYSTICK_CLOCK_HZ );
+	}
+	#endif /* configUSE_TICKLESS_IDLE */
+
 	/* Stop and reset the SysTick. */
-	*( portNVIC_SYSTICK_CTRL ) = 0UL;
-	*( portNVIC_SYSTICK_CURRENT_VALUE ) = 0UL;
+	portNVIC_SYSTICK_CTRL_REG = 0UL;
+	portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
 
 	/* Configure SysTick to interrupt at the requested rate. */
-	*( portNVIC_SYSTICK_LOAD ) = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
-	*( portNVIC_SYSTICK_CTRL ) = portNVIC_SYSTICK_CLK | portNVIC_SYSTICK_INT | portNVIC_SYSTICK_ENABLE;
+	portNVIC_SYSTICK_LOAD_REG = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
+	portNVIC_SYSTICK_CTRL_REG = portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT | portNVIC_SYSTICK_ENABLE_BIT;
 }
 /*-----------------------------------------------------------*/
 
@@ -435,11 +662,11 @@ volatile uint32_t ulDummy = 0UL;
 								( portMPU_RLAR_REGION_ENABLE );
 
 			/* Enable mem fault. */
-			portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_MEM_FAULT_ENABLE;
+			portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_MEM_FAULT_ENABLE_BIT;
 
 			/* Enable MPU with privileged background access i.e. unmapped
 			 * regions have privileged access. */
-			portMPU_CTRL_REG |= ( portMPU_PRIV_BACKGROUND_ENABLE | portMPU_ENABLE );
+			portMPU_CTRL_REG |= ( portMPU_PRIV_BACKGROUND_ENABLE_BIT | portMPU_ENABLE_BIT );
 		}
 	}
 #endif /* configENABLE_MPU */
@@ -473,7 +700,7 @@ volatile uint32_t ulDummy = 0UL;
 void vPortYield( void ) /* PRIVILEGED_FUNCTION */
 {
 	/* Set a PendSV to request a context switch. */
-	*( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET;
+	portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
 
 	/* Barriers are normally not required but do ensure the code is
 	 * completely within the specified behaviour for the architecture. */
@@ -516,7 +743,7 @@ uint32_t ulPreviousMask;
 		if( xTaskIncrementTick() != pdFALSE )
 		{
 			/* Pend a context switch. */
-			*( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET;
+			portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
 		}
 	}
 	portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );
@@ -761,8 +988,8 @@ uint8_t ucSVCNumber;
 BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
 {
 	/* Make PendSV, CallSV and SysTick the same priority as the kernel. */
-	*( portNVIC_SYSPRI2 ) |= portNVIC_PENDSV_PRI;
-	*( portNVIC_SYSPRI2 ) |= portNVIC_SYSTICK_PRI;
+	portNVIC_SYSPRI2_REG |= portNVIC_PENDSV_PRI;
+	portNVIC_SYSPRI2_REG |= portNVIC_SYSTICK_PRI;
 
 	#if( configENABLE_MPU == 1 )
 	{
@@ -773,7 +1000,7 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
 
 	/* Start the timer that generates the tick ISR. Interrupts are disabled
 	 * here already. */
-	prvSetupTimerInterrupt();
+	vPortSetupTimerInterrupt();
 
 	/* Initialize the critical nesting count ready for the first task. */
 	ulCriticalNesting = 0;
@@ -896,4 +1123,27 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
 		}
 	}
 #endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+BaseType_t xPortIsInsideInterrupt( void )
+{
+uint32_t ulCurrentInterrupt;
+BaseType_t xReturn;
+
+	/* Obtain the number of the currently executing interrupt. Interrupt Program
+	 * Status Register (IPSR) holds the exception number of the currently-executing
+	 * exception or zero for Thread mode.*/
+	__asm volatile( "mrs %0, ipsr" : "=r"( ulCurrentInterrupt ) :: "memory" );
+
+	if( ulCurrentInterrupt == 0 )
+	{
+		xReturn = pdFALSE;
+	}
+	else
+	{
+		xReturn = pdTRUE;
+	}
+
+	return xReturn;
+}
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM23/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM23/non_secure/portasm.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -201,7 +201,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-uint32_t ulSetInterruptMaskFromISR( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
 {
 	__asm volatile
 	(
@@ -210,17 +210,10 @@ uint32_t ulSetInterruptMaskFromISR( void ) /* __attribute__(( naked )) PRIVILEGE
 	"	bx lr											\n"
 	::: "memory"
 	);
-
-#if !defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-	/* To avoid compiler warnings.  The return statement will never be reached,
-	 * but some compilers warn if it is not included, while others won't compile
-	 * if it is. */
-	return 0;
-#endif
 }
 /*-----------------------------------------------------------*/
 
-void vClearInterruptMaskFromISR( __attribute__( ( unused ) ) uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
 {
 	__asm volatile
 	(
@@ -228,14 +221,6 @@ void vClearInterruptMaskFromISR( __attribute__( ( unused ) ) uint32_t ulMask ) /
 	"	bx lr											\n"
 	::: "memory"
 	);
-
-#if !defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-	/* Just to avoid compiler warning.  ulMask is used from the asm code but
-	 * the compiler can't see that.  Some compilers generate warnings without
-	 * the following line, while others generate warnings if the line is
-	 * included. */
-	( void ) ulMask;
-#endif
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23/non_secure/portasm.h
+++ b/portable/GCC/ARM_CM23/non_secure/portasm.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -78,12 +78,12 @@ void vStartFirstTask( void ) __attribute__ (( naked )) PRIVILEGED_FUNCTION;
 /**
  * @brief Disables interrupts.
  */
-uint32_t ulSetInterruptMaskFromISR( void ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
+uint32_t ulSetInterruptMask( void ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Enables interrupts.
  */
-void vClearInterruptMaskFromISR( uint32_t ulMask ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
+void vClearInterruptMask( uint32_t ulMask ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
 
 /**
  * @brief PendSV Exception handler.

--- a/portable/GCC/ARM_CM23/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacro.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -103,13 +103,15 @@ typedef unsigned long										UBaseType_t;
 /**
  * @brief Extern declarations.
  */
+extern BaseType_t xPortIsInsideInterrupt( void );
+
 extern void vPortYield( void ) /* PRIVILEGED_FUNCTION */;
 
 extern void vPortEnterCritical( void ) /* PRIVILEGED_FUNCTION */;
 extern void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */;
 
-extern uint32_t ulSetInterruptMaskFromISR( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
-extern void vClearInterruptMaskFromISR( uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+extern uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
 
 #if( configENABLE_TRUSTZONE == 1 )
 	extern void vPortAllocateSecureContext( uint32_t ulSecureStackSize ); /* __attribute__ (( naked )) */
@@ -217,12 +219,21 @@ typedef struct MPU_SETTINGS
 /**
  * @brief Critical section management.
  */
-#define portSET_INTERRUPT_MASK_FROM_ISR()					ulSetInterruptMaskFromISR()
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR(x)				vClearInterruptMaskFromISR( x )
+#define portSET_INTERRUPT_MASK_FROM_ISR()					ulSetInterruptMask()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR(x)				vClearInterruptMask( x )
 #define portDISABLE_INTERRUPTS()							__asm volatile ( " cpsid i " ::: "memory" )
 #define portENABLE_INTERRUPTS()								__asm volatile ( " cpsie i " ::: "memory" )
 #define portENTER_CRITICAL()								vPortEnterCritical()
 #define portEXIT_CRITICAL()									vPortExitCritical()
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Tickless idle/low power functionality.
+ */
+#ifndef portSUPPRESS_TICKS_AND_SLEEP
+	extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
+	#define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime ) vPortSuppressTicksAndSleep( xExpectedIdleTime )
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM23/secure/secure_context.c
+++ b/portable/GCC/ARM_CM23/secure/secure_context.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM23/secure/secure_context.h
+++ b/portable/GCC/ARM_CM23/secure/secure_context.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM23/secure/secure_context_port.c
+++ b/portable/GCC/ARM_CM23/secure/secure_context_port.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM23/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM23/secure/secure_heap.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM23/secure/secure_heap.h
+++ b/portable/GCC/ARM_CM23/secure/secure_heap.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM23/secure/secure_init.c
+++ b/portable/GCC/ARM_CM23/secure/secure_init.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM23/secure/secure_init.h
+++ b/portable/GCC/ARM_CM23/secure/secure_init.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM23/secure/secure_port_macros.h
+++ b/portable/GCC/ARM_CM23/secure/secure_port_macros.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -71,25 +71,32 @@
 /**
  * @brief Constants required to manipulate the NVIC.
  */
-#define portNVIC_SYSTICK_CTRL				( ( volatile uint32_t * ) 0xe000e010 )
-#define portNVIC_SYSTICK_LOAD				( ( volatile uint32_t * ) 0xe000e014 )
-#define portNVIC_SYSTICK_CURRENT_VALUE		( ( volatile uint32_t * ) 0xe000e018 )
-#define portNVIC_INT_CTRL					( ( volatile uint32_t * ) 0xe000ed04 )
-#define portNVIC_SYSPRI2					( ( volatile uint32_t * ) 0xe000ed20 )
-#define portNVIC_SYSTICK_CLK				( 0x00000004 )
-#define portNVIC_SYSTICK_INT				( 0x00000002 )
-#define portNVIC_SYSTICK_ENABLE				( 0x00000001 )
-#define portNVIC_PENDSVSET					( 0x10000000 )
+#define portNVIC_SYSTICK_CTRL_REG			( * ( ( volatile uint32_t * ) 0xe000e010 ) )
+#define portNVIC_SYSTICK_LOAD_REG			( * ( ( volatile uint32_t * ) 0xe000e014 ) )
+#define portNVIC_SYSTICK_CURRENT_VALUE_REG	( * ( ( volatile uint32_t * ) 0xe000e018 ) )
+#define portNVIC_SYSPRI2_REG				( * ( ( volatile uint32_t * ) 0xe000ed20 ) )
+#define portNVIC_SYSTICK_ENABLE_BIT			( 1UL << 0UL )
+#define portNVIC_SYSTICK_INT_BIT			( 1UL << 1UL )
+#define portNVIC_SYSTICK_COUNT_FLAG_BIT		( 1UL << 16UL )
 #define portMIN_INTERRUPT_PRIORITY			( 255UL )
 #define portNVIC_PENDSV_PRI					( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI				( portMIN_INTERRUPT_PRIORITY << 24UL )
+#ifndef configSYSTICK_CLOCK_HZ
+	#define configSYSTICK_CLOCK_HZ			configCPU_CLOCK_HZ
+	/* Ensure the SysTick is clocked at the same frequency as the core. */
+	#define portNVIC_SYSTICK_CLK_BIT		( 1UL << 2UL )
+#else
+	/* The way the SysTick is clocked is not modified in case it is not the
+	 * same a the core. */
+	#define portNVIC_SYSTICK_CLK_BIT		( 0 )
+#endif
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Constants required to manipulate the SCB.
  */
 #define portSCB_SYS_HANDLER_CTRL_STATE_REG	( * ( volatile uint32_t * ) 0xe000ed24 )
-#define portSCB_MEM_FAULT_ENABLE			( 1UL << 16UL )
+#define portSCB_MEM_FAULT_ENABLE_BIT		( 1UL << 16UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -169,13 +176,28 @@
 #define portMPU_RLAR_REGION_ENABLE			( 1UL )
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE		( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT	( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE						( 1UL << 0UL )
+#define portMPU_ENABLE_BIT					( 1UL << 0UL )
 
 /* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE			( 8UL << 8UL ) /* 8 regions, unified. */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The maximum 24-bit number.
+ *
+ * It is needed because the systick is a 24-bit counter.
+ */
+#define portMAX_24_BIT_NUMBER				( 0xffffffUL )
+
+/**
+ * @brief A fiddle factor to estimate the number of SysTick counts that would
+ * have occurred while the SysTick counter is stopped during tickless idle
+ * calculations.
+ */
+#define portMISSED_COUNTS_FACTOR			( 45UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -258,11 +280,6 @@
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Setup the timer to generate the tick interrupts.
- */
-static void prvSetupTimerInterrupt( void ) PRIVILEGED_FUNCTION;
-
-/**
  * @brief Used to catch tasks that attempt to return from their implementing
  * function.
  */
@@ -281,6 +298,22 @@ static void prvTaskExitError( void );
 	 */
 	static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
+
+/**
+ * @brief Setup the timer to generate the tick interrupts.
+ *
+ * The implementation in this file is weak to allow application writers to
+ * change the timer used to generate the tick interrupt.
+ */
+void vPortSetupTimerInterrupt( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Checks whether the current execution context is interrupt.
+ *
+ * @return pdTRUE if the current execution context is interrupt, pdFALSE
+ * otherwise.
+ */
+BaseType_t xPortIsInsideInterrupt( void );
 
 /**
  * @brief Yield the processor.
@@ -321,17 +354,211 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 	 */
 	portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
 #endif /* configENABLE_TRUSTZONE */
+
+#if( configUSE_TICKLESS_IDLE == 1 )
+	/**
+	 * @brief The number of SysTick increments that make up one tick period.
+	 */
+	static uint32_t ulTimerCountsForOneTick = 0;
+
+	/**
+	 * @brief The maximum number of tick periods that can be suppressed is
+	 * limited by the 24 bit resolution of the SysTick timer.
+	 */
+	static uint32_t xMaximumPossibleSuppressedTicks = 0;
+
+	/**
+	 * @brief Compensate for the CPU cycles that pass while the SysTick is
+	 * stopped (low power functionality only).
+	 */
+	static uint32_t ulStoppedTimerCompensation = 0;
+#endif /* configUSE_TICKLESS_IDLE */
 /*-----------------------------------------------------------*/
 
-static void prvSetupTimerInterrupt( void ) /* PRIVILEGED_FUNCTION */
+#if( configUSE_TICKLESS_IDLE == 1 )
+	__attribute__(( weak )) void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime )
+	{
+	uint32_t ulReloadValue, ulCompleteTickPeriods, ulCompletedSysTickDecrements;
+	TickType_t xModifiableIdleTime;
+
+		/* Make sure the SysTick reload value does not overflow the counter. */
+		if( xExpectedIdleTime > xMaximumPossibleSuppressedTicks )
+		{
+			xExpectedIdleTime = xMaximumPossibleSuppressedTicks;
+		}
+
+		/* Stop the SysTick momentarily. The time the SysTick is stopped for is
+		 * accounted for as best it can be, but using the tickless mode will
+		 * inevitably result in some tiny drift of the time maintained by the
+		 * kernel with respect to calendar time. */
+		portNVIC_SYSTICK_CTRL_REG &= ~portNVIC_SYSTICK_ENABLE_BIT;
+
+		/* Calculate the reload value required to wait xExpectedIdleTime
+		 * tick periods. -1 is used because this code will execute part way
+		 * through one of the tick periods. */
+		ulReloadValue = portNVIC_SYSTICK_CURRENT_VALUE_REG + ( ulTimerCountsForOneTick * ( xExpectedIdleTime - 1UL ) );
+		if( ulReloadValue > ulStoppedTimerCompensation )
+		{
+			ulReloadValue -= ulStoppedTimerCompensation;
+		}
+
+		/* Enter a critical section but don't use the taskENTER_CRITICAL()
+		 * method as that will mask interrupts that should exit sleep mode. */
+		__asm volatile( "cpsid i" ::: "memory" );
+		__asm volatile( "dsb" );
+		__asm volatile( "isb" );
+
+		/* If a context switch is pending or a task is waiting for the scheduler
+		 * to be un-suspended then abandon the low power entry. */
+		if( eTaskConfirmSleepModeStatus() == eAbortSleep )
+		{
+			/* Restart from whatever is left in the count register to complete
+			 * this tick period. */
+			portNVIC_SYSTICK_LOAD_REG = portNVIC_SYSTICK_CURRENT_VALUE_REG;
+
+			/* Restart SysTick. */
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+
+			/* Reset the reload register to the value required for normal tick
+			 * periods. */
+			portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
+
+			/* Re-enable interrupts - see comments above the cpsid instruction()
+			 * above. */
+			__asm volatile( "cpsie i" ::: "memory" );
+		}
+		else
+		{
+			/* Set the new reload value. */
+			portNVIC_SYSTICK_LOAD_REG = ulReloadValue;
+
+			/* Clear the SysTick count flag and set the count value back to
+			 * zero. */
+			portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+
+			/* Restart SysTick. */
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+
+			/* Sleep until something happens. configPRE_SLEEP_PROCESSING() can
+			 * set its parameter to 0 to indicate that its implementation
+			 * contains its own wait for interrupt or wait for event
+			 * instruction, and so wfi should not be executed again. However,
+			 * the original expected idle time variable must remain unmodified,
+			 * so a copy is taken. */
+			xModifiableIdleTime = xExpectedIdleTime;
+			configPRE_SLEEP_PROCESSING( xModifiableIdleTime );
+			if( xModifiableIdleTime > 0 )
+			{
+				__asm volatile( "dsb" ::: "memory" );
+				__asm volatile( "wfi" );
+				__asm volatile( "isb" );
+			}
+			configPOST_SLEEP_PROCESSING( xExpectedIdleTime );
+
+			/* Re-enable interrupts to allow the interrupt that brought the MCU
+			 * out of sleep mode to execute immediately. See comments above
+			 * the cpsid instruction above. */
+			__asm volatile( "cpsie i" ::: "memory" );
+			__asm volatile( "dsb" );
+			__asm volatile( "isb" );
+
+			/* Disable interrupts again because the clock is about to be stopped
+			 * and interrupts that execute while the clock is stopped will
+			 * increase any slippage between the time maintained by the RTOS and
+			 * calendar time. */
+			__asm volatile( "cpsid i" ::: "memory" );
+			__asm volatile( "dsb" );
+			__asm volatile( "isb" );
+
+			/* Disable the SysTick clock without reading the
+			 * portNVIC_SYSTICK_CTRL_REG register to ensure the
+			 * portNVIC_SYSTICK_COUNT_FLAG_BIT is not cleared if it is set.
+			 * Again, the time the SysTick is stopped for is accounted for as
+			 * best it can be, but using the tickless mode will inevitably
+			 * result in some tiny drift of the time maintained by the kernel
+			 * with respect to calendar time*/
+			portNVIC_SYSTICK_CTRL_REG = ( portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT );
+
+			/* Determine if the SysTick clock has already counted to zero and
+			 * been set back to the current reload value (the reload back being
+			 * correct for the entire expected idle time) or if the SysTick is
+			 * yet to count to zero (in which case an interrupt other than the
+			 * SysTick must have brought the system out of sleep mode). */
+			if( ( portNVIC_SYSTICK_CTRL_REG & portNVIC_SYSTICK_COUNT_FLAG_BIT ) != 0 )
+			{
+				uint32_t ulCalculatedLoadValue;
+
+				/* The tick interrupt is already pending, and the SysTick count
+				 * reloaded with ulReloadValue.  Reset the
+				 * portNVIC_SYSTICK_LOAD_REG with whatever remains of this tick
+				 * period. */
+				ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL ) - ( ulReloadValue - portNVIC_SYSTICK_CURRENT_VALUE_REG );
+
+				/* Don't allow a tiny value, or values that have somehow
+				 * underflowed because the post sleep hook did something
+				 * that took too long. */
+				if( ( ulCalculatedLoadValue < ulStoppedTimerCompensation ) || ( ulCalculatedLoadValue > ulTimerCountsForOneTick ) )
+				{
+					ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL );
+				}
+
+				portNVIC_SYSTICK_LOAD_REG = ulCalculatedLoadValue;
+
+				/* As the pending tick will be processed as soon as this
+				 * function exits, the tick value maintained by the tick is
+				 * stepped forward by one less than the time spent waiting. */
+				ulCompleteTickPeriods = xExpectedIdleTime - 1UL;
+			}
+			else
+			{
+				/* Something other than the tick interrupt ended the sleep.
+				 * Work out how long the sleep lasted rounded to complete tick
+				 * periods (not the ulReload value which accounted for part
+				 * ticks). */
+				ulCompletedSysTickDecrements = ( xExpectedIdleTime * ulTimerCountsForOneTick ) - portNVIC_SYSTICK_CURRENT_VALUE_REG;
+
+				/* How many complete tick periods passed while the processor
+				 * was waiting? */
+				ulCompleteTickPeriods = ulCompletedSysTickDecrements / ulTimerCountsForOneTick;
+
+				/* The reload value is set to whatever fraction of a single tick
+				 * period remains. */
+				portNVIC_SYSTICK_LOAD_REG = ( ( ulCompleteTickPeriods + 1UL ) * ulTimerCountsForOneTick ) - ulCompletedSysTickDecrements;
+			}
+
+			/* Restart SysTick so it runs from portNVIC_SYSTICK_LOAD_REG
+			 * again, then set portNVIC_SYSTICK_LOAD_REG back to its standard
+			 * value. */
+			portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+			vTaskStepTick( ulCompleteTickPeriods );
+			portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
+
+			/* Exit with interrupts enabled. */
+			__asm volatile( "cpsie i" ::: "memory" );
+		}
+	}
+#endif /* configUSE_TICKLESS_IDLE */
+/*-----------------------------------------------------------*/
+
+__attribute__(( weak )) void vPortSetupTimerInterrupt( void ) /* PRIVILEGED_FUNCTION */
 {
+	/* Calculate the constants required to configure the tick interrupt. */
+	#if( configUSE_TICKLESS_IDLE == 1 )
+	{
+		ulTimerCountsForOneTick = ( configSYSTICK_CLOCK_HZ / configTICK_RATE_HZ );
+		xMaximumPossibleSuppressedTicks = portMAX_24_BIT_NUMBER / ulTimerCountsForOneTick;
+		ulStoppedTimerCompensation = portMISSED_COUNTS_FACTOR / ( configCPU_CLOCK_HZ / configSYSTICK_CLOCK_HZ );
+	}
+	#endif /* configUSE_TICKLESS_IDLE */
+
 	/* Stop and reset the SysTick. */
-	*( portNVIC_SYSTICK_CTRL ) = 0UL;
-	*( portNVIC_SYSTICK_CURRENT_VALUE ) = 0UL;
+	portNVIC_SYSTICK_CTRL_REG = 0UL;
+	portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
 
 	/* Configure SysTick to interrupt at the requested rate. */
-	*( portNVIC_SYSTICK_LOAD ) = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
-	*( portNVIC_SYSTICK_CTRL ) = portNVIC_SYSTICK_CLK | portNVIC_SYSTICK_INT | portNVIC_SYSTICK_ENABLE;
+	portNVIC_SYSTICK_LOAD_REG = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
+	portNVIC_SYSTICK_CTRL_REG = portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT | portNVIC_SYSTICK_ENABLE_BIT;
 }
 /*-----------------------------------------------------------*/
 
@@ -435,11 +662,11 @@ volatile uint32_t ulDummy = 0UL;
 								( portMPU_RLAR_REGION_ENABLE );
 
 			/* Enable mem fault. */
-			portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_MEM_FAULT_ENABLE;
+			portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_MEM_FAULT_ENABLE_BIT;
 
 			/* Enable MPU with privileged background access i.e. unmapped
 			 * regions have privileged access. */
-			portMPU_CTRL_REG |= ( portMPU_PRIV_BACKGROUND_ENABLE | portMPU_ENABLE );
+			portMPU_CTRL_REG |= ( portMPU_PRIV_BACKGROUND_ENABLE_BIT | portMPU_ENABLE_BIT );
 		}
 	}
 #endif /* configENABLE_MPU */
@@ -473,7 +700,7 @@ volatile uint32_t ulDummy = 0UL;
 void vPortYield( void ) /* PRIVILEGED_FUNCTION */
 {
 	/* Set a PendSV to request a context switch. */
-	*( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET;
+	portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
 
 	/* Barriers are normally not required but do ensure the code is
 	 * completely within the specified behaviour for the architecture. */
@@ -516,7 +743,7 @@ uint32_t ulPreviousMask;
 		if( xTaskIncrementTick() != pdFALSE )
 		{
 			/* Pend a context switch. */
-			*( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET;
+			portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
 		}
 	}
 	portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );
@@ -761,8 +988,8 @@ uint8_t ucSVCNumber;
 BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
 {
 	/* Make PendSV, CallSV and SysTick the same priority as the kernel. */
-	*( portNVIC_SYSPRI2 ) |= portNVIC_PENDSV_PRI;
-	*( portNVIC_SYSPRI2 ) |= portNVIC_SYSTICK_PRI;
+	portNVIC_SYSPRI2_REG |= portNVIC_PENDSV_PRI;
+	portNVIC_SYSPRI2_REG |= portNVIC_SYSTICK_PRI;
 
 	#if( configENABLE_MPU == 1 )
 	{
@@ -773,7 +1000,7 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
 
 	/* Start the timer that generates the tick ISR. Interrupts are disabled
 	 * here already. */
-	prvSetupTimerInterrupt();
+	vPortSetupTimerInterrupt();
 
 	/* Initialize the critical nesting count ready for the first task. */
 	ulCriticalNesting = 0;
@@ -896,4 +1123,27 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
 		}
 	}
 #endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+BaseType_t xPortIsInsideInterrupt( void )
+{
+uint32_t ulCurrentInterrupt;
+BaseType_t xReturn;
+
+	/* Obtain the number of the currently executing interrupt. Interrupt Program
+	 * Status Register (IPSR) holds the exception number of the currently-executing
+	 * exception or zero for Thread mode.*/
+	__asm volatile( "mrs %0, ipsr" : "=r"( ulCurrentInterrupt ) :: "memory" );
+
+	if( ulCurrentInterrupt == 0 )
+	{
+		xReturn = pdFALSE;
+	}
+	else
+	{
+		xReturn = pdTRUE;
+	}
+
+	return xReturn;
+}
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -196,7 +196,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-uint32_t ulSetInterruptMaskFromISR( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
 {
 	__asm volatile
 	(
@@ -205,17 +205,10 @@ uint32_t ulSetInterruptMaskFromISR( void ) /* __attribute__(( naked )) PRIVILEGE
 	"	bx lr											\n"
 	::: "memory"
 	);
-
-#if !defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-	/* To avoid compiler warnings.  The return statement will never be reached,
-	 * but some compilers warn if it is not included, while others won't compile
-	 * if it is. */
-	return 0;
-#endif
 }
 /*-----------------------------------------------------------*/
 
-void vClearInterruptMaskFromISR( __attribute__( ( unused ) ) uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
 {
 	__asm volatile
 	(
@@ -223,14 +216,6 @@ void vClearInterruptMaskFromISR( __attribute__( ( unused ) ) uint32_t ulMask ) /
 	"	bx lr											\n"
 	::: "memory"
 	);
-
-#if !defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-	/* Just to avoid compiler warning.  ulMask is used from the asm code but
-	 * the compiler can't see that.  Some compilers generate warnings without
-	 * the following line, while others generate warnings if the line is
-	 * included. */
-	( void ) ulMask;
-#endif
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -78,12 +78,12 @@ void vStartFirstTask( void ) __attribute__ (( naked )) PRIVILEGED_FUNCTION;
 /**
  * @brief Disables interrupts.
  */
-uint32_t ulSetInterruptMaskFromISR( void ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
+uint32_t ulSetInterruptMask( void ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Enables interrupts.
  */
-void vClearInterruptMaskFromISR( uint32_t ulMask ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
+void vClearInterruptMask( uint32_t ulMask ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
 
 /**
  * @brief PendSV Exception handler.

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -103,13 +103,15 @@ typedef unsigned long										UBaseType_t;
 /**
  * @brief Extern declarations.
  */
+extern BaseType_t xPortIsInsideInterrupt( void );
+
 extern void vPortYield( void ) /* PRIVILEGED_FUNCTION */;
 
 extern void vPortEnterCritical( void ) /* PRIVILEGED_FUNCTION */;
 extern void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */;
 
-extern uint32_t ulSetInterruptMaskFromISR( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
-extern void vClearInterruptMaskFromISR( uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+extern uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
 
 #if( configENABLE_TRUSTZONE == 1 )
 	extern void vPortAllocateSecureContext( uint32_t ulSecureStackSize ); /* __attribute__ (( naked )) */
@@ -217,12 +219,21 @@ typedef struct MPU_SETTINGS
 /**
  * @brief Critical section management.
  */
-#define portSET_INTERRUPT_MASK_FROM_ISR()					ulSetInterruptMaskFromISR()
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR(x)				vClearInterruptMaskFromISR( x )
+#define portSET_INTERRUPT_MASK_FROM_ISR()					ulSetInterruptMask()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR(x)				vClearInterruptMask( x )
 #define portDISABLE_INTERRUPTS()							__asm volatile ( " cpsid i " ::: "memory" )
 #define portENABLE_INTERRUPTS()								__asm volatile ( " cpsie i " ::: "memory" )
 #define portENTER_CRITICAL()								vPortEnterCritical()
 #define portEXIT_CRITICAL()									vPortExitCritical()
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Tickless idle/low power functionality.
+ */
+#ifndef portSUPPRESS_TICKS_AND_SLEEP
+	extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
+	#define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime ) vPortSuppressTicksAndSleep( xExpectedIdleTime )
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM3/port.c
+++ b/portable/GCC/ARM_CM3/port.c
@@ -247,6 +247,7 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg 				\n" /* Ensure the pool is placed here, so ldr doesn't generate a too long jump */
 				);
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM3/port.c
+++ b/portable/GCC/ARM_CM3/port.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -247,7 +247,6 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
-					" .ltorg 				\n" /* Ensure the pool is placed here, so ldr doesn't generate a too long jump */
 				);
 }
 /*-----------------------------------------------------------*/
@@ -515,14 +514,14 @@ void xPortSysTickHandler( void )
 			should not be executed again.  However, the original expected idle
 			time variable must remain unmodified, so a copy is taken. */
 			xModifiableIdleTime = xExpectedIdleTime;
-			configPRE_SLEEP_PROCESSING( &xModifiableIdleTime );
+			configPRE_SLEEP_PROCESSING( xModifiableIdleTime );
 			if( xModifiableIdleTime > 0 )
 			{
 				__asm volatile( "dsb" ::: "memory" );
 				__asm volatile( "wfi" );
 				__asm volatile( "isb" );
 			}
-			configPOST_SLEEP_PROCESSING( &xExpectedIdleTime );
+			configPOST_SLEEP_PROCESSING( xExpectedIdleTime );
 
 			/* Re-enable interrupts to allow the interrupt that brought the MCU
 			out of sleep mode to execute immediately.  see comments above
@@ -603,7 +602,7 @@ void xPortSysTickHandler( void )
 			vTaskStepTick( ulCompleteTickPeriods );
 			portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
 
-			/* Exit with interrpts enabled. */
+			/* Exit with interrupts enabled. */
 			__asm volatile( "cpsie i" ::: "memory" );
 		}
 	}

--- a/portable/GCC/ARM_CM3/portmacro.h
+++ b/portable/GCC/ARM_CM3/portmacro.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -165,6 +165,8 @@ not necessary for to use this port.  They are defined so the common demo files
 #ifndef portFORCE_INLINE
 	#define portFORCE_INLINE inline __attribute__(( always_inline))
 #endif
+
+/*-----------------------------------------------------------*/
 
 portFORCE_INLINE static BaseType_t xPortIsInsideInterrupt( void )
 {

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -71,25 +71,32 @@
 /**
  * @brief Constants required to manipulate the NVIC.
  */
-#define portNVIC_SYSTICK_CTRL				( ( volatile uint32_t * ) 0xe000e010 )
-#define portNVIC_SYSTICK_LOAD				( ( volatile uint32_t * ) 0xe000e014 )
-#define portNVIC_SYSTICK_CURRENT_VALUE		( ( volatile uint32_t * ) 0xe000e018 )
-#define portNVIC_INT_CTRL					( ( volatile uint32_t * ) 0xe000ed04 )
-#define portNVIC_SYSPRI2					( ( volatile uint32_t * ) 0xe000ed20 )
-#define portNVIC_SYSTICK_CLK				( 0x00000004 )
-#define portNVIC_SYSTICK_INT				( 0x00000002 )
-#define portNVIC_SYSTICK_ENABLE				( 0x00000001 )
-#define portNVIC_PENDSVSET					( 0x10000000 )
+#define portNVIC_SYSTICK_CTRL_REG			( * ( ( volatile uint32_t * ) 0xe000e010 ) )
+#define portNVIC_SYSTICK_LOAD_REG			( * ( ( volatile uint32_t * ) 0xe000e014 ) )
+#define portNVIC_SYSTICK_CURRENT_VALUE_REG	( * ( ( volatile uint32_t * ) 0xe000e018 ) )
+#define portNVIC_SYSPRI2_REG				( * ( ( volatile uint32_t * ) 0xe000ed20 ) )
+#define portNVIC_SYSTICK_ENABLE_BIT			( 1UL << 0UL )
+#define portNVIC_SYSTICK_INT_BIT			( 1UL << 1UL )
+#define portNVIC_SYSTICK_COUNT_FLAG_BIT		( 1UL << 16UL )
 #define portMIN_INTERRUPT_PRIORITY			( 255UL )
 #define portNVIC_PENDSV_PRI					( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI				( portMIN_INTERRUPT_PRIORITY << 24UL )
+#ifndef configSYSTICK_CLOCK_HZ
+	#define configSYSTICK_CLOCK_HZ			configCPU_CLOCK_HZ
+	/* Ensure the SysTick is clocked at the same frequency as the core. */
+	#define portNVIC_SYSTICK_CLK_BIT		( 1UL << 2UL )
+#else
+	/* The way the SysTick is clocked is not modified in case it is not the
+	 * same a the core. */
+	#define portNVIC_SYSTICK_CLK_BIT		( 0 )
+#endif
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Constants required to manipulate the SCB.
  */
 #define portSCB_SYS_HANDLER_CTRL_STATE_REG	( * ( volatile uint32_t * ) 0xe000ed24 )
-#define portSCB_MEM_FAULT_ENABLE			( 1UL << 16UL )
+#define portSCB_MEM_FAULT_ENABLE_BIT		( 1UL << 16UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -169,13 +176,28 @@
 #define portMPU_RLAR_REGION_ENABLE			( 1UL )
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE		( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT	( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE						( 1UL << 0UL )
+#define portMPU_ENABLE_BIT					( 1UL << 0UL )
 
 /* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE			( 8UL << 8UL ) /* 8 regions, unified. */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The maximum 24-bit number.
+ *
+ * It is needed because the systick is a 24-bit counter.
+ */
+#define portMAX_24_BIT_NUMBER				( 0xffffffUL )
+
+/**
+ * @brief A fiddle factor to estimate the number of SysTick counts that would
+ * have occurred while the SysTick counter is stopped during tickless idle
+ * calculations.
+ */
+#define portMISSED_COUNTS_FACTOR			( 45UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -258,11 +280,6 @@
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Setup the timer to generate the tick interrupts.
- */
-static void prvSetupTimerInterrupt( void ) PRIVILEGED_FUNCTION;
-
-/**
  * @brief Used to catch tasks that attempt to return from their implementing
  * function.
  */
@@ -281,6 +298,22 @@ static void prvTaskExitError( void );
 	 */
 	static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
+
+/**
+ * @brief Setup the timer to generate the tick interrupts.
+ *
+ * The implementation in this file is weak to allow application writers to
+ * change the timer used to generate the tick interrupt.
+ */
+void vPortSetupTimerInterrupt( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Checks whether the current execution context is interrupt.
+ *
+ * @return pdTRUE if the current execution context is interrupt, pdFALSE
+ * otherwise.
+ */
+BaseType_t xPortIsInsideInterrupt( void );
 
 /**
  * @brief Yield the processor.
@@ -321,17 +354,211 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 	 */
 	portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
 #endif /* configENABLE_TRUSTZONE */
+
+#if( configUSE_TICKLESS_IDLE == 1 )
+	/**
+	 * @brief The number of SysTick increments that make up one tick period.
+	 */
+	static uint32_t ulTimerCountsForOneTick = 0;
+
+	/**
+	 * @brief The maximum number of tick periods that can be suppressed is
+	 * limited by the 24 bit resolution of the SysTick timer.
+	 */
+	static uint32_t xMaximumPossibleSuppressedTicks = 0;
+
+	/**
+	 * @brief Compensate for the CPU cycles that pass while the SysTick is
+	 * stopped (low power functionality only).
+	 */
+	static uint32_t ulStoppedTimerCompensation = 0;
+#endif /* configUSE_TICKLESS_IDLE */
 /*-----------------------------------------------------------*/
 
-static void prvSetupTimerInterrupt( void ) /* PRIVILEGED_FUNCTION */
+#if( configUSE_TICKLESS_IDLE == 1 )
+	__attribute__(( weak )) void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime )
+	{
+	uint32_t ulReloadValue, ulCompleteTickPeriods, ulCompletedSysTickDecrements;
+	TickType_t xModifiableIdleTime;
+
+		/* Make sure the SysTick reload value does not overflow the counter. */
+		if( xExpectedIdleTime > xMaximumPossibleSuppressedTicks )
+		{
+			xExpectedIdleTime = xMaximumPossibleSuppressedTicks;
+		}
+
+		/* Stop the SysTick momentarily. The time the SysTick is stopped for is
+		 * accounted for as best it can be, but using the tickless mode will
+		 * inevitably result in some tiny drift of the time maintained by the
+		 * kernel with respect to calendar time. */
+		portNVIC_SYSTICK_CTRL_REG &= ~portNVIC_SYSTICK_ENABLE_BIT;
+
+		/* Calculate the reload value required to wait xExpectedIdleTime
+		 * tick periods. -1 is used because this code will execute part way
+		 * through one of the tick periods. */
+		ulReloadValue = portNVIC_SYSTICK_CURRENT_VALUE_REG + ( ulTimerCountsForOneTick * ( xExpectedIdleTime - 1UL ) );
+		if( ulReloadValue > ulStoppedTimerCompensation )
+		{
+			ulReloadValue -= ulStoppedTimerCompensation;
+		}
+
+		/* Enter a critical section but don't use the taskENTER_CRITICAL()
+		 * method as that will mask interrupts that should exit sleep mode. */
+		__asm volatile( "cpsid i" ::: "memory" );
+		__asm volatile( "dsb" );
+		__asm volatile( "isb" );
+
+		/* If a context switch is pending or a task is waiting for the scheduler
+		 * to be un-suspended then abandon the low power entry. */
+		if( eTaskConfirmSleepModeStatus() == eAbortSleep )
+		{
+			/* Restart from whatever is left in the count register to complete
+			 * this tick period. */
+			portNVIC_SYSTICK_LOAD_REG = portNVIC_SYSTICK_CURRENT_VALUE_REG;
+
+			/* Restart SysTick. */
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+
+			/* Reset the reload register to the value required for normal tick
+			 * periods. */
+			portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
+
+			/* Re-enable interrupts - see comments above the cpsid instruction()
+			 * above. */
+			__asm volatile( "cpsie i" ::: "memory" );
+		}
+		else
+		{
+			/* Set the new reload value. */
+			portNVIC_SYSTICK_LOAD_REG = ulReloadValue;
+
+			/* Clear the SysTick count flag and set the count value back to
+			 * zero. */
+			portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+
+			/* Restart SysTick. */
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+
+			/* Sleep until something happens. configPRE_SLEEP_PROCESSING() can
+			 * set its parameter to 0 to indicate that its implementation
+			 * contains its own wait for interrupt or wait for event
+			 * instruction, and so wfi should not be executed again. However,
+			 * the original expected idle time variable must remain unmodified,
+			 * so a copy is taken. */
+			xModifiableIdleTime = xExpectedIdleTime;
+			configPRE_SLEEP_PROCESSING( xModifiableIdleTime );
+			if( xModifiableIdleTime > 0 )
+			{
+				__asm volatile( "dsb" ::: "memory" );
+				__asm volatile( "wfi" );
+				__asm volatile( "isb" );
+			}
+			configPOST_SLEEP_PROCESSING( xExpectedIdleTime );
+
+			/* Re-enable interrupts to allow the interrupt that brought the MCU
+			 * out of sleep mode to execute immediately. See comments above
+			 * the cpsid instruction above. */
+			__asm volatile( "cpsie i" ::: "memory" );
+			__asm volatile( "dsb" );
+			__asm volatile( "isb" );
+
+			/* Disable interrupts again because the clock is about to be stopped
+			 * and interrupts that execute while the clock is stopped will
+			 * increase any slippage between the time maintained by the RTOS and
+			 * calendar time. */
+			__asm volatile( "cpsid i" ::: "memory" );
+			__asm volatile( "dsb" );
+			__asm volatile( "isb" );
+
+			/* Disable the SysTick clock without reading the
+			 * portNVIC_SYSTICK_CTRL_REG register to ensure the
+			 * portNVIC_SYSTICK_COUNT_FLAG_BIT is not cleared if it is set.
+			 * Again, the time the SysTick is stopped for is accounted for as
+			 * best it can be, but using the tickless mode will inevitably
+			 * result in some tiny drift of the time maintained by the kernel
+			 * with respect to calendar time*/
+			portNVIC_SYSTICK_CTRL_REG = ( portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT );
+
+			/* Determine if the SysTick clock has already counted to zero and
+			 * been set back to the current reload value (the reload back being
+			 * correct for the entire expected idle time) or if the SysTick is
+			 * yet to count to zero (in which case an interrupt other than the
+			 * SysTick must have brought the system out of sleep mode). */
+			if( ( portNVIC_SYSTICK_CTRL_REG & portNVIC_SYSTICK_COUNT_FLAG_BIT ) != 0 )
+			{
+				uint32_t ulCalculatedLoadValue;
+
+				/* The tick interrupt is already pending, and the SysTick count
+				 * reloaded with ulReloadValue.  Reset the
+				 * portNVIC_SYSTICK_LOAD_REG with whatever remains of this tick
+				 * period. */
+				ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL ) - ( ulReloadValue - portNVIC_SYSTICK_CURRENT_VALUE_REG );
+
+				/* Don't allow a tiny value, or values that have somehow
+				 * underflowed because the post sleep hook did something
+				 * that took too long. */
+				if( ( ulCalculatedLoadValue < ulStoppedTimerCompensation ) || ( ulCalculatedLoadValue > ulTimerCountsForOneTick ) )
+				{
+					ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL );
+				}
+
+				portNVIC_SYSTICK_LOAD_REG = ulCalculatedLoadValue;
+
+				/* As the pending tick will be processed as soon as this
+				 * function exits, the tick value maintained by the tick is
+				 * stepped forward by one less than the time spent waiting. */
+				ulCompleteTickPeriods = xExpectedIdleTime - 1UL;
+			}
+			else
+			{
+				/* Something other than the tick interrupt ended the sleep.
+				 * Work out how long the sleep lasted rounded to complete tick
+				 * periods (not the ulReload value which accounted for part
+				 * ticks). */
+				ulCompletedSysTickDecrements = ( xExpectedIdleTime * ulTimerCountsForOneTick ) - portNVIC_SYSTICK_CURRENT_VALUE_REG;
+
+				/* How many complete tick periods passed while the processor
+				 * was waiting? */
+				ulCompleteTickPeriods = ulCompletedSysTickDecrements / ulTimerCountsForOneTick;
+
+				/* The reload value is set to whatever fraction of a single tick
+				 * period remains. */
+				portNVIC_SYSTICK_LOAD_REG = ( ( ulCompleteTickPeriods + 1UL ) * ulTimerCountsForOneTick ) - ulCompletedSysTickDecrements;
+			}
+
+			/* Restart SysTick so it runs from portNVIC_SYSTICK_LOAD_REG
+			 * again, then set portNVIC_SYSTICK_LOAD_REG back to its standard
+			 * value. */
+			portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+			vTaskStepTick( ulCompleteTickPeriods );
+			portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
+
+			/* Exit with interrupts enabled. */
+			__asm volatile( "cpsie i" ::: "memory" );
+		}
+	}
+#endif /* configUSE_TICKLESS_IDLE */
+/*-----------------------------------------------------------*/
+
+__attribute__(( weak )) void vPortSetupTimerInterrupt( void ) /* PRIVILEGED_FUNCTION */
 {
+	/* Calculate the constants required to configure the tick interrupt. */
+	#if( configUSE_TICKLESS_IDLE == 1 )
+	{
+		ulTimerCountsForOneTick = ( configSYSTICK_CLOCK_HZ / configTICK_RATE_HZ );
+		xMaximumPossibleSuppressedTicks = portMAX_24_BIT_NUMBER / ulTimerCountsForOneTick;
+		ulStoppedTimerCompensation = portMISSED_COUNTS_FACTOR / ( configCPU_CLOCK_HZ / configSYSTICK_CLOCK_HZ );
+	}
+	#endif /* configUSE_TICKLESS_IDLE */
+
 	/* Stop and reset the SysTick. */
-	*( portNVIC_SYSTICK_CTRL ) = 0UL;
-	*( portNVIC_SYSTICK_CURRENT_VALUE ) = 0UL;
+	portNVIC_SYSTICK_CTRL_REG = 0UL;
+	portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
 
 	/* Configure SysTick to interrupt at the requested rate. */
-	*( portNVIC_SYSTICK_LOAD ) = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
-	*( portNVIC_SYSTICK_CTRL ) = portNVIC_SYSTICK_CLK | portNVIC_SYSTICK_INT | portNVIC_SYSTICK_ENABLE;
+	portNVIC_SYSTICK_LOAD_REG = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
+	portNVIC_SYSTICK_CTRL_REG = portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT | portNVIC_SYSTICK_ENABLE_BIT;
 }
 /*-----------------------------------------------------------*/
 
@@ -435,11 +662,11 @@ volatile uint32_t ulDummy = 0UL;
 								( portMPU_RLAR_REGION_ENABLE );
 
 			/* Enable mem fault. */
-			portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_MEM_FAULT_ENABLE;
+			portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_MEM_FAULT_ENABLE_BIT;
 
 			/* Enable MPU with privileged background access i.e. unmapped
 			 * regions have privileged access. */
-			portMPU_CTRL_REG |= ( portMPU_PRIV_BACKGROUND_ENABLE | portMPU_ENABLE );
+			portMPU_CTRL_REG |= ( portMPU_PRIV_BACKGROUND_ENABLE_BIT | portMPU_ENABLE_BIT );
 		}
 	}
 #endif /* configENABLE_MPU */
@@ -473,7 +700,7 @@ volatile uint32_t ulDummy = 0UL;
 void vPortYield( void ) /* PRIVILEGED_FUNCTION */
 {
 	/* Set a PendSV to request a context switch. */
-	*( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET;
+	portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
 
 	/* Barriers are normally not required but do ensure the code is
 	 * completely within the specified behaviour for the architecture. */
@@ -516,7 +743,7 @@ uint32_t ulPreviousMask;
 		if( xTaskIncrementTick() != pdFALSE )
 		{
 			/* Pend a context switch. */
-			*( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET;
+			portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
 		}
 	}
 	portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );
@@ -761,8 +988,8 @@ uint8_t ucSVCNumber;
 BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
 {
 	/* Make PendSV, CallSV and SysTick the same priority as the kernel. */
-	*( portNVIC_SYSPRI2 ) |= portNVIC_PENDSV_PRI;
-	*( portNVIC_SYSPRI2 ) |= portNVIC_SYSTICK_PRI;
+	portNVIC_SYSPRI2_REG |= portNVIC_PENDSV_PRI;
+	portNVIC_SYSPRI2_REG |= portNVIC_SYSTICK_PRI;
 
 	#if( configENABLE_MPU == 1 )
 	{
@@ -773,7 +1000,7 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
 
 	/* Start the timer that generates the tick ISR. Interrupts are disabled
 	 * here already. */
-	prvSetupTimerInterrupt();
+	vPortSetupTimerInterrupt();
 
 	/* Initialize the critical nesting count ready for the first task. */
 	ulCriticalNesting = 0;
@@ -896,4 +1123,27 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
 		}
 	}
 #endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+BaseType_t xPortIsInsideInterrupt( void )
+{
+uint32_t ulCurrentInterrupt;
+BaseType_t xReturn;
+
+	/* Obtain the number of the currently executing interrupt. Interrupt Program
+	 * Status Register (IPSR) holds the exception number of the currently-executing
+	 * exception or zero for Thread mode.*/
+	__asm volatile( "mrs %0, ipsr" : "=r"( ulCurrentInterrupt ) :: "memory" );
+
+	if( ulCurrentInterrupt == 0 )
+	{
+		xReturn = pdFALSE;
+	}
+	else
+	{
+		xReturn = pdTRUE;
+	}
+
+	return xReturn;
+}
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33/non_secure/portasm.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -176,41 +176,31 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-uint32_t ulSetInterruptMaskFromISR( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
 {
 	__asm volatile
 	(
-	"	mrs r0, PRIMASK									\n"
-	"	cpsid i											\n"
-	"	bx lr											\n"
-	::: "memory"
+	"	mrs r0, basepri									\n" /* r0 = basepri. Return original basepri value. */
+	"	mov r1, %0										\n" /* r1 = configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+	"	msr basepri, r1									\n" /* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+	"	dsb												\n"
+	"	isb												\n"
+	"	bx lr											\n" /* Return. */
+	:: "i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) : "memory"
 	);
-
-#if !defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-	/* To avoid compiler warnings.  The return statement will never be reached,
-	 * but some compilers warn if it is not included, while others won't compile
-	 * if it is. */
-	return 0;
-#endif
 }
 /*-----------------------------------------------------------*/
 
-void vClearInterruptMaskFromISR( __attribute__( ( unused ) ) uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
 {
 	__asm volatile
 	(
-	"	msr PRIMASK, r0									\n"
-	"	bx lr											\n"
+	"	msr basepri, r0									\n" /* basepri = ulMask. */
+	"	dsb												\n"
+	"	isb												\n"
+	"	bx lr											\n" /* Return. */
 	::: "memory"
 	);
-
-#if !defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-	/* Just to avoid compiler warning.  ulMask is used from the asm code but
-	 * the compiler can't see that.  Some compilers generate warnings without
-	 * the following line, while others generate warnings if the line is
-	 * included. */
-	( void ) ulMask;
-#endif
 }
 /*-----------------------------------------------------------*/
 
@@ -281,9 +271,13 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 	#endif /* configENABLE_MPU */
 	"													\n"
 	" select_next_task:									\n"
-	"	cpsid i											\n"
+	"	mov r0, %0										\n" /* r0 = configMAX_SYSCALL_INTERRUPT_PRIORITY */
+	"	msr basepri, r0									\n" /* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+	"	dsb												\n"
+	"	isb												\n"
 	"	bl vTaskSwitchContext							\n"
-	"	cpsie i											\n"
+	"	mov r0, #0										\n" /* r0 = 0. */
+	"	msr basepri, r0									\n" /* Enable interrupts. */
 	"													\n"
 	"	ldr r2, pxCurrentTCBConst						\n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
 	"	ldr r3, [r2]									\n" /* Read pxCurrentTCB. */
@@ -367,6 +361,7 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 	"xRNRConst: .word 0xe000ed98						\n"
 	"xRBARConst: .word 0xe000ed9c						\n"
 	#endif /* configENABLE_MPU */
+	:: "i"( configMAX_SYSCALL_INTERRUPT_PRIORITY )
 	);
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33/non_secure/portasm.h
+++ b/portable/GCC/ARM_CM33/non_secure/portasm.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -78,12 +78,12 @@ void vStartFirstTask( void ) __attribute__ (( naked )) PRIVILEGED_FUNCTION;
 /**
  * @brief Disables interrupts.
  */
-uint32_t ulSetInterruptMaskFromISR( void ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
+uint32_t ulSetInterruptMask( void ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Enables interrupts.
  */
-void vClearInterruptMaskFromISR( uint32_t ulMask ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
+void vClearInterruptMask( uint32_t ulMask ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
 
 /**
  * @brief PendSV Exception handler.

--- a/portable/GCC/ARM_CM33/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacro.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -103,13 +103,15 @@ typedef unsigned long										UBaseType_t;
 /**
  * @brief Extern declarations.
  */
+extern BaseType_t xPortIsInsideInterrupt( void );
+
 extern void vPortYield( void ) /* PRIVILEGED_FUNCTION */;
 
 extern void vPortEnterCritical( void ) /* PRIVILEGED_FUNCTION */;
 extern void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */;
 
-extern uint32_t ulSetInterruptMaskFromISR( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
-extern void vClearInterruptMaskFromISR( uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+extern uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
 
 #if( configENABLE_TRUSTZONE == 1 )
 	extern void vPortAllocateSecureContext( uint32_t ulSecureStackSize ); /* __attribute__ (( naked )) */
@@ -217,12 +219,21 @@ typedef struct MPU_SETTINGS
 /**
  * @brief Critical section management.
  */
-#define portSET_INTERRUPT_MASK_FROM_ISR()					ulSetInterruptMaskFromISR()
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR(x)				vClearInterruptMaskFromISR( x )
-#define portDISABLE_INTERRUPTS()							__asm volatile ( " cpsid i " ::: "memory" )
-#define portENABLE_INTERRUPTS()								__asm volatile ( " cpsie i " ::: "memory" )
+#define portSET_INTERRUPT_MASK_FROM_ISR()					ulSetInterruptMask()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR( x )				vClearInterruptMask( x )
+#define portDISABLE_INTERRUPTS()							ulSetInterruptMask()
+#define portENABLE_INTERRUPTS()								vClearInterruptMask( 0 )
 #define portENTER_CRITICAL()								vPortEnterCritical()
 #define portEXIT_CRITICAL()									vPortExitCritical()
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Tickless idle/low power functionality.
+ */
+#ifndef portSUPPRESS_TICKS_AND_SLEEP
+	extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
+	#define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime ) vPortSuppressTicksAndSleep( xExpectedIdleTime )
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM33/secure/secure_context.c
+++ b/portable/GCC/ARM_CM33/secure/secure_context.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM33/secure/secure_context.h
+++ b/portable/GCC/ARM_CM33/secure/secure_context.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM33/secure/secure_context_port.c
+++ b/portable/GCC/ARM_CM33/secure/secure_context_port.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM33/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM33/secure/secure_heap.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM33/secure/secure_heap.h
+++ b/portable/GCC/ARM_CM33/secure/secure_heap.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM33/secure/secure_init.c
+++ b/portable/GCC/ARM_CM33/secure/secure_init.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM33/secure/secure_init.h
+++ b/portable/GCC/ARM_CM33/secure/secure_init.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM33/secure/secure_port_macros.h
+++ b/portable/GCC/ARM_CM33/secure/secure_port_macros.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -71,25 +71,32 @@
 /**
  * @brief Constants required to manipulate the NVIC.
  */
-#define portNVIC_SYSTICK_CTRL				( ( volatile uint32_t * ) 0xe000e010 )
-#define portNVIC_SYSTICK_LOAD				( ( volatile uint32_t * ) 0xe000e014 )
-#define portNVIC_SYSTICK_CURRENT_VALUE		( ( volatile uint32_t * ) 0xe000e018 )
-#define portNVIC_INT_CTRL					( ( volatile uint32_t * ) 0xe000ed04 )
-#define portNVIC_SYSPRI2					( ( volatile uint32_t * ) 0xe000ed20 )
-#define portNVIC_SYSTICK_CLK				( 0x00000004 )
-#define portNVIC_SYSTICK_INT				( 0x00000002 )
-#define portNVIC_SYSTICK_ENABLE				( 0x00000001 )
-#define portNVIC_PENDSVSET					( 0x10000000 )
+#define portNVIC_SYSTICK_CTRL_REG			( * ( ( volatile uint32_t * ) 0xe000e010 ) )
+#define portNVIC_SYSTICK_LOAD_REG			( * ( ( volatile uint32_t * ) 0xe000e014 ) )
+#define portNVIC_SYSTICK_CURRENT_VALUE_REG	( * ( ( volatile uint32_t * ) 0xe000e018 ) )
+#define portNVIC_SYSPRI2_REG				( * ( ( volatile uint32_t * ) 0xe000ed20 ) )
+#define portNVIC_SYSTICK_ENABLE_BIT			( 1UL << 0UL )
+#define portNVIC_SYSTICK_INT_BIT			( 1UL << 1UL )
+#define portNVIC_SYSTICK_COUNT_FLAG_BIT		( 1UL << 16UL )
 #define portMIN_INTERRUPT_PRIORITY			( 255UL )
 #define portNVIC_PENDSV_PRI					( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI				( portMIN_INTERRUPT_PRIORITY << 24UL )
+#ifndef configSYSTICK_CLOCK_HZ
+	#define configSYSTICK_CLOCK_HZ			configCPU_CLOCK_HZ
+	/* Ensure the SysTick is clocked at the same frequency as the core. */
+	#define portNVIC_SYSTICK_CLK_BIT		( 1UL << 2UL )
+#else
+	/* The way the SysTick is clocked is not modified in case it is not the
+	 * same a the core. */
+	#define portNVIC_SYSTICK_CLK_BIT		( 0 )
+#endif
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Constants required to manipulate the SCB.
  */
 #define portSCB_SYS_HANDLER_CTRL_STATE_REG	( * ( volatile uint32_t * ) 0xe000ed24 )
-#define portSCB_MEM_FAULT_ENABLE			( 1UL << 16UL )
+#define portSCB_MEM_FAULT_ENABLE_BIT		( 1UL << 16UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -169,13 +176,28 @@
 #define portMPU_RLAR_REGION_ENABLE			( 1UL )
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE		( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT	( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE						( 1UL << 0UL )
+#define portMPU_ENABLE_BIT					( 1UL << 0UL )
 
 /* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE			( 8UL << 8UL ) /* 8 regions, unified. */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The maximum 24-bit number.
+ *
+ * It is needed because the systick is a 24-bit counter.
+ */
+#define portMAX_24_BIT_NUMBER				( 0xffffffUL )
+
+/**
+ * @brief A fiddle factor to estimate the number of SysTick counts that would
+ * have occurred while the SysTick counter is stopped during tickless idle
+ * calculations.
+ */
+#define portMISSED_COUNTS_FACTOR			( 45UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -258,11 +280,6 @@
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Setup the timer to generate the tick interrupts.
- */
-static void prvSetupTimerInterrupt( void ) PRIVILEGED_FUNCTION;
-
-/**
  * @brief Used to catch tasks that attempt to return from their implementing
  * function.
  */
@@ -281,6 +298,22 @@ static void prvTaskExitError( void );
 	 */
 	static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
+
+/**
+ * @brief Setup the timer to generate the tick interrupts.
+ *
+ * The implementation in this file is weak to allow application writers to
+ * change the timer used to generate the tick interrupt.
+ */
+void vPortSetupTimerInterrupt( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Checks whether the current execution context is interrupt.
+ *
+ * @return pdTRUE if the current execution context is interrupt, pdFALSE
+ * otherwise.
+ */
+BaseType_t xPortIsInsideInterrupt( void );
 
 /**
  * @brief Yield the processor.
@@ -321,17 +354,211 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 	 */
 	portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
 #endif /* configENABLE_TRUSTZONE */
+
+#if( configUSE_TICKLESS_IDLE == 1 )
+	/**
+	 * @brief The number of SysTick increments that make up one tick period.
+	 */
+	static uint32_t ulTimerCountsForOneTick = 0;
+
+	/**
+	 * @brief The maximum number of tick periods that can be suppressed is
+	 * limited by the 24 bit resolution of the SysTick timer.
+	 */
+	static uint32_t xMaximumPossibleSuppressedTicks = 0;
+
+	/**
+	 * @brief Compensate for the CPU cycles that pass while the SysTick is
+	 * stopped (low power functionality only).
+	 */
+	static uint32_t ulStoppedTimerCompensation = 0;
+#endif /* configUSE_TICKLESS_IDLE */
 /*-----------------------------------------------------------*/
 
-static void prvSetupTimerInterrupt( void ) /* PRIVILEGED_FUNCTION */
+#if( configUSE_TICKLESS_IDLE == 1 )
+	__attribute__(( weak )) void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime )
+	{
+	uint32_t ulReloadValue, ulCompleteTickPeriods, ulCompletedSysTickDecrements;
+	TickType_t xModifiableIdleTime;
+
+		/* Make sure the SysTick reload value does not overflow the counter. */
+		if( xExpectedIdleTime > xMaximumPossibleSuppressedTicks )
+		{
+			xExpectedIdleTime = xMaximumPossibleSuppressedTicks;
+		}
+
+		/* Stop the SysTick momentarily. The time the SysTick is stopped for is
+		 * accounted for as best it can be, but using the tickless mode will
+		 * inevitably result in some tiny drift of the time maintained by the
+		 * kernel with respect to calendar time. */
+		portNVIC_SYSTICK_CTRL_REG &= ~portNVIC_SYSTICK_ENABLE_BIT;
+
+		/* Calculate the reload value required to wait xExpectedIdleTime
+		 * tick periods. -1 is used because this code will execute part way
+		 * through one of the tick periods. */
+		ulReloadValue = portNVIC_SYSTICK_CURRENT_VALUE_REG + ( ulTimerCountsForOneTick * ( xExpectedIdleTime - 1UL ) );
+		if( ulReloadValue > ulStoppedTimerCompensation )
+		{
+			ulReloadValue -= ulStoppedTimerCompensation;
+		}
+
+		/* Enter a critical section but don't use the taskENTER_CRITICAL()
+		 * method as that will mask interrupts that should exit sleep mode. */
+		__asm volatile( "cpsid i" ::: "memory" );
+		__asm volatile( "dsb" );
+		__asm volatile( "isb" );
+
+		/* If a context switch is pending or a task is waiting for the scheduler
+		 * to be un-suspended then abandon the low power entry. */
+		if( eTaskConfirmSleepModeStatus() == eAbortSleep )
+		{
+			/* Restart from whatever is left in the count register to complete
+			 * this tick period. */
+			portNVIC_SYSTICK_LOAD_REG = portNVIC_SYSTICK_CURRENT_VALUE_REG;
+
+			/* Restart SysTick. */
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+
+			/* Reset the reload register to the value required for normal tick
+			 * periods. */
+			portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
+
+			/* Re-enable interrupts - see comments above the cpsid instruction()
+			 * above. */
+			__asm volatile( "cpsie i" ::: "memory" );
+		}
+		else
+		{
+			/* Set the new reload value. */
+			portNVIC_SYSTICK_LOAD_REG = ulReloadValue;
+
+			/* Clear the SysTick count flag and set the count value back to
+			 * zero. */
+			portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+
+			/* Restart SysTick. */
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+
+			/* Sleep until something happens. configPRE_SLEEP_PROCESSING() can
+			 * set its parameter to 0 to indicate that its implementation
+			 * contains its own wait for interrupt or wait for event
+			 * instruction, and so wfi should not be executed again. However,
+			 * the original expected idle time variable must remain unmodified,
+			 * so a copy is taken. */
+			xModifiableIdleTime = xExpectedIdleTime;
+			configPRE_SLEEP_PROCESSING( xModifiableIdleTime );
+			if( xModifiableIdleTime > 0 )
+			{
+				__asm volatile( "dsb" ::: "memory" );
+				__asm volatile( "wfi" );
+				__asm volatile( "isb" );
+			}
+			configPOST_SLEEP_PROCESSING( xExpectedIdleTime );
+
+			/* Re-enable interrupts to allow the interrupt that brought the MCU
+			 * out of sleep mode to execute immediately. See comments above
+			 * the cpsid instruction above. */
+			__asm volatile( "cpsie i" ::: "memory" );
+			__asm volatile( "dsb" );
+			__asm volatile( "isb" );
+
+			/* Disable interrupts again because the clock is about to be stopped
+			 * and interrupts that execute while the clock is stopped will
+			 * increase any slippage between the time maintained by the RTOS and
+			 * calendar time. */
+			__asm volatile( "cpsid i" ::: "memory" );
+			__asm volatile( "dsb" );
+			__asm volatile( "isb" );
+
+			/* Disable the SysTick clock without reading the
+			 * portNVIC_SYSTICK_CTRL_REG register to ensure the
+			 * portNVIC_SYSTICK_COUNT_FLAG_BIT is not cleared if it is set.
+			 * Again, the time the SysTick is stopped for is accounted for as
+			 * best it can be, but using the tickless mode will inevitably
+			 * result in some tiny drift of the time maintained by the kernel
+			 * with respect to calendar time*/
+			portNVIC_SYSTICK_CTRL_REG = ( portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT );
+
+			/* Determine if the SysTick clock has already counted to zero and
+			 * been set back to the current reload value (the reload back being
+			 * correct for the entire expected idle time) or if the SysTick is
+			 * yet to count to zero (in which case an interrupt other than the
+			 * SysTick must have brought the system out of sleep mode). */
+			if( ( portNVIC_SYSTICK_CTRL_REG & portNVIC_SYSTICK_COUNT_FLAG_BIT ) != 0 )
+			{
+				uint32_t ulCalculatedLoadValue;
+
+				/* The tick interrupt is already pending, and the SysTick count
+				 * reloaded with ulReloadValue.  Reset the
+				 * portNVIC_SYSTICK_LOAD_REG with whatever remains of this tick
+				 * period. */
+				ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL ) - ( ulReloadValue - portNVIC_SYSTICK_CURRENT_VALUE_REG );
+
+				/* Don't allow a tiny value, or values that have somehow
+				 * underflowed because the post sleep hook did something
+				 * that took too long. */
+				if( ( ulCalculatedLoadValue < ulStoppedTimerCompensation ) || ( ulCalculatedLoadValue > ulTimerCountsForOneTick ) )
+				{
+					ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL );
+				}
+
+				portNVIC_SYSTICK_LOAD_REG = ulCalculatedLoadValue;
+
+				/* As the pending tick will be processed as soon as this
+				 * function exits, the tick value maintained by the tick is
+				 * stepped forward by one less than the time spent waiting. */
+				ulCompleteTickPeriods = xExpectedIdleTime - 1UL;
+			}
+			else
+			{
+				/* Something other than the tick interrupt ended the sleep.
+				 * Work out how long the sleep lasted rounded to complete tick
+				 * periods (not the ulReload value which accounted for part
+				 * ticks). */
+				ulCompletedSysTickDecrements = ( xExpectedIdleTime * ulTimerCountsForOneTick ) - portNVIC_SYSTICK_CURRENT_VALUE_REG;
+
+				/* How many complete tick periods passed while the processor
+				 * was waiting? */
+				ulCompleteTickPeriods = ulCompletedSysTickDecrements / ulTimerCountsForOneTick;
+
+				/* The reload value is set to whatever fraction of a single tick
+				 * period remains. */
+				portNVIC_SYSTICK_LOAD_REG = ( ( ulCompleteTickPeriods + 1UL ) * ulTimerCountsForOneTick ) - ulCompletedSysTickDecrements;
+			}
+
+			/* Restart SysTick so it runs from portNVIC_SYSTICK_LOAD_REG
+			 * again, then set portNVIC_SYSTICK_LOAD_REG back to its standard
+			 * value. */
+			portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+			portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+			vTaskStepTick( ulCompleteTickPeriods );
+			portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
+
+			/* Exit with interrupts enabled. */
+			__asm volatile( "cpsie i" ::: "memory" );
+		}
+	}
+#endif /* configUSE_TICKLESS_IDLE */
+/*-----------------------------------------------------------*/
+
+__attribute__(( weak )) void vPortSetupTimerInterrupt( void ) /* PRIVILEGED_FUNCTION */
 {
+	/* Calculate the constants required to configure the tick interrupt. */
+	#if( configUSE_TICKLESS_IDLE == 1 )
+	{
+		ulTimerCountsForOneTick = ( configSYSTICK_CLOCK_HZ / configTICK_RATE_HZ );
+		xMaximumPossibleSuppressedTicks = portMAX_24_BIT_NUMBER / ulTimerCountsForOneTick;
+		ulStoppedTimerCompensation = portMISSED_COUNTS_FACTOR / ( configCPU_CLOCK_HZ / configSYSTICK_CLOCK_HZ );
+	}
+	#endif /* configUSE_TICKLESS_IDLE */
+
 	/* Stop and reset the SysTick. */
-	*( portNVIC_SYSTICK_CTRL ) = 0UL;
-	*( portNVIC_SYSTICK_CURRENT_VALUE ) = 0UL;
+	portNVIC_SYSTICK_CTRL_REG = 0UL;
+	portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
 
 	/* Configure SysTick to interrupt at the requested rate. */
-	*( portNVIC_SYSTICK_LOAD ) = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
-	*( portNVIC_SYSTICK_CTRL ) = portNVIC_SYSTICK_CLK | portNVIC_SYSTICK_INT | portNVIC_SYSTICK_ENABLE;
+	portNVIC_SYSTICK_LOAD_REG = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
+	portNVIC_SYSTICK_CTRL_REG = portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT | portNVIC_SYSTICK_ENABLE_BIT;
 }
 /*-----------------------------------------------------------*/
 
@@ -435,11 +662,11 @@ volatile uint32_t ulDummy = 0UL;
 								( portMPU_RLAR_REGION_ENABLE );
 
 			/* Enable mem fault. */
-			portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_MEM_FAULT_ENABLE;
+			portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_MEM_FAULT_ENABLE_BIT;
 
 			/* Enable MPU with privileged background access i.e. unmapped
 			 * regions have privileged access. */
-			portMPU_CTRL_REG |= ( portMPU_PRIV_BACKGROUND_ENABLE | portMPU_ENABLE );
+			portMPU_CTRL_REG |= ( portMPU_PRIV_BACKGROUND_ENABLE_BIT | portMPU_ENABLE_BIT );
 		}
 	}
 #endif /* configENABLE_MPU */
@@ -473,7 +700,7 @@ volatile uint32_t ulDummy = 0UL;
 void vPortYield( void ) /* PRIVILEGED_FUNCTION */
 {
 	/* Set a PendSV to request a context switch. */
-	*( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET;
+	portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
 
 	/* Barriers are normally not required but do ensure the code is
 	 * completely within the specified behaviour for the architecture. */
@@ -516,7 +743,7 @@ uint32_t ulPreviousMask;
 		if( xTaskIncrementTick() != pdFALSE )
 		{
 			/* Pend a context switch. */
-			*( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET;
+			portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
 		}
 	}
 	portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );
@@ -761,8 +988,8 @@ uint8_t ucSVCNumber;
 BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
 {
 	/* Make PendSV, CallSV and SysTick the same priority as the kernel. */
-	*( portNVIC_SYSPRI2 ) |= portNVIC_PENDSV_PRI;
-	*( portNVIC_SYSPRI2 ) |= portNVIC_SYSTICK_PRI;
+	portNVIC_SYSPRI2_REG |= portNVIC_PENDSV_PRI;
+	portNVIC_SYSPRI2_REG |= portNVIC_SYSTICK_PRI;
 
 	#if( configENABLE_MPU == 1 )
 	{
@@ -773,7 +1000,7 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
 
 	/* Start the timer that generates the tick ISR. Interrupts are disabled
 	 * here already. */
-	prvSetupTimerInterrupt();
+	vPortSetupTimerInterrupt();
 
 	/* Initialize the critical nesting count ready for the first task. */
 	ulCriticalNesting = 0;
@@ -896,4 +1123,27 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
 		}
 	}
 #endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+BaseType_t xPortIsInsideInterrupt( void )
+{
+uint32_t ulCurrentInterrupt;
+BaseType_t xReturn;
+
+	/* Obtain the number of the currently executing interrupt. Interrupt Program
+	 * Status Register (IPSR) holds the exception number of the currently-executing
+	 * exception or zero for Thread mode.*/
+	__asm volatile( "mrs %0, ipsr" : "=r"( ulCurrentInterrupt ) :: "memory" );
+
+	if( ulCurrentInterrupt == 0 )
+	{
+		xReturn = pdFALSE;
+	}
+	else
+	{
+		xReturn = pdTRUE;
+	}
+
+	return xReturn;
+}
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -333,7 +333,9 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+/* Fix for STM32 core */
+/* void SysTick_Handler( void ) PRIVILEGED_FUNCTION; */
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -733,7 +735,9 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+/* Fix for STM32 core */
+/* void SysTick_Handler( void ) */ /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
 uint32_t ulPreviousMask;
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -171,41 +171,31 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-uint32_t ulSetInterruptMaskFromISR( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
 {
 	__asm volatile
 	(
-	"	mrs r0, PRIMASK									\n"
-	"	cpsid i											\n"
-	"	bx lr											\n"
-	::: "memory"
+	"	mrs r0, basepri									\n" /* r0 = basepri. Return original basepri value. */
+	"	mov r1, %0										\n" /* r1 = configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+	"	msr basepri, r1									\n" /* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+	"	dsb												\n"
+	"	isb												\n"
+	"	bx lr											\n" /* Return. */
+	:: "i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) : "memory"
 	);
-
-#if !defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-	/* To avoid compiler warnings.  The return statement will never be reached,
-	 * but some compilers warn if it is not included, while others won't compile
-	 * if it is. */
-	return 0;
-#endif
 }
 /*-----------------------------------------------------------*/
 
-void vClearInterruptMaskFromISR( __attribute__( ( unused ) ) uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
 {
 	__asm volatile
 	(
-	"	msr PRIMASK, r0									\n"
-	"	bx lr											\n"
+	"	msr basepri, r0									\n" /* basepri = ulMask. */
+	"	dsb												\n"
+	"	isb												\n"
+	"	bx lr											\n" /* Return. */
 	::: "memory"
 	);
-
-#if !defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-	/* Just to avoid compiler warning.  ulMask is used from the asm code but
-	 * the compiler can't see that.  Some compilers generate warnings without
-	 * the following line, while others generate warnings if the line is
-	 * included. */
-	( void ) ulMask;
-#endif
 }
 /*-----------------------------------------------------------*/
 
@@ -236,9 +226,13 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 	"	ldr r1, [r2]									\n" /* Read pxCurrentTCB. */
 	"	str r0, [r1]									\n" /* Save the new top of stack in TCB. */
 	"													\n"
-	"	cpsid i											\n"
+	"	mov r0, %0										\n" /* r0 = configMAX_SYSCALL_INTERRUPT_PRIORITY */
+	"	msr basepri, r0									\n" /* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+	"	dsb												\n"
+	"	isb												\n"
 	"	bl vTaskSwitchContext							\n"
-	"	cpsie i											\n"
+	"	mov r0, #0										\n" /* r0 = 0. */
+	"	msr basepri, r0									\n" /* Enable interrupts. */
 	"													\n"
 	"	ldr r2, pxCurrentTCBConst						\n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
 	"	ldr r1, [r2]									\n" /* Read pxCurrentTCB. */
@@ -299,6 +293,7 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 	"xRNRConst: .word 0xe000ed98						\n"
 	"xRBARConst: .word 0xe000ed9c						\n"
 	#endif /* configENABLE_MPU */
+	:: "i"( configMAX_SYSCALL_INTERRUPT_PRIORITY )
 	);
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -78,12 +78,12 @@ void vStartFirstTask( void ) __attribute__ (( naked )) PRIVILEGED_FUNCTION;
 /**
  * @brief Disables interrupts.
  */
-uint32_t ulSetInterruptMaskFromISR( void ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
+uint32_t ulSetInterruptMask( void ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Enables interrupts.
  */
-void vClearInterruptMaskFromISR( uint32_t ulMask ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
+void vClearInterruptMask( uint32_t ulMask ) __attribute__(( naked )) PRIVILEGED_FUNCTION;
 
 /**
  * @brief PendSV Exception handler.

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -103,13 +103,15 @@ typedef unsigned long										UBaseType_t;
 /**
  * @brief Extern declarations.
  */
+extern BaseType_t xPortIsInsideInterrupt( void );
+
 extern void vPortYield( void ) /* PRIVILEGED_FUNCTION */;
 
 extern void vPortEnterCritical( void ) /* PRIVILEGED_FUNCTION */;
 extern void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */;
 
-extern uint32_t ulSetInterruptMaskFromISR( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
-extern void vClearInterruptMaskFromISR( uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+extern uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
 
 #if( configENABLE_TRUSTZONE == 1 )
 	extern void vPortAllocateSecureContext( uint32_t ulSecureStackSize ); /* __attribute__ (( naked )) */
@@ -217,12 +219,21 @@ typedef struct MPU_SETTINGS
 /**
  * @brief Critical section management.
  */
-#define portSET_INTERRUPT_MASK_FROM_ISR()					ulSetInterruptMaskFromISR()
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR(x)				vClearInterruptMaskFromISR( x )
-#define portDISABLE_INTERRUPTS()							__asm volatile ( " cpsid i " ::: "memory" )
-#define portENABLE_INTERRUPTS()								__asm volatile ( " cpsie i " ::: "memory" )
+#define portSET_INTERRUPT_MASK_FROM_ISR()					ulSetInterruptMask()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR(x)				vClearInterruptMask( x )
+#define portDISABLE_INTERRUPTS()							ulSetInterruptMask()
+#define portENABLE_INTERRUPTS()								vClearInterruptMask( 0 )
 #define portENTER_CRITICAL()								vPortEnterCritical()
 #define portEXIT_CRITICAL()									vPortExitCritical()
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Tickless idle/low power functionality.
+ */
+#ifndef portSUPPRESS_TICKS_AND_SLEEP
+	extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
+	#define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime ) vPortSuppressTicksAndSleep( xExpectedIdleTime )
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -30,8 +30,8 @@
  *----------------------------------------------------------*/
 
 /* Defining MPU_WRAPPERS_INCLUDED_FROM_API_FILE prevents task.h from redefining
-all the API functions to use the MPU wrappers.  That should only be done when
-task.h is included from an application file. */
+ * all the API functions to use the MPU wrappers.  That should only be done when
+ * task.h is included from an application file. */
 #define MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 
 /* Scheduler includes. */
@@ -46,7 +46,7 @@ task.h is included from an application file. */
 	#define portNVIC_SYSTICK_CLK	( 1UL << 2UL )
 #else
 	/* The way the SysTick is clocked is not modified in case it is not the same
-	as the core. */
+	 * as the core. */
 	#define portNVIC_SYSTICK_CLK	( 0 )
 #endif
 
@@ -86,21 +86,22 @@ task.h is included from an application file. */
 #define portINITIAL_CONTROL_IF_PRIVILEGED		( 0x02 )
 
 /* Constants required to check the validity of an interrupt priority. */
-#define portFIRST_USER_INTERRUPT_NUMBER		( 16 )
-#define portNVIC_IP_REGISTERS_OFFSET_16 	( 0xE000E3F0 )
-#define portAIRCR_REG						( * ( ( volatile uint32_t * ) 0xE000ED0C ) )
-#define portMAX_8_BIT_VALUE					( ( uint8_t ) 0xff )
-#define portTOP_BIT_OF_BYTE					( ( uint8_t ) 0x80 )
-#define portMAX_PRIGROUP_BITS				( ( uint8_t ) 7 )
-#define portPRIORITY_GROUP_MASK				( 0x07UL << 8UL )
-#define portPRIGROUP_SHIFT					( 8UL )
+#define portFIRST_USER_INTERRUPT_NUMBER			( 16 )
+#define portNVIC_IP_REGISTERS_OFFSET_16 		( 0xE000E3F0 )
+#define portAIRCR_REG							( * ( ( volatile uint32_t * ) 0xE000ED0C ) )
+#define portMAX_8_BIT_VALUE						( ( uint8_t ) 0xff )
+#define portTOP_BIT_OF_BYTE						( ( uint8_t ) 0x80 )
+#define portMAX_PRIGROUP_BITS					( ( uint8_t ) 7 )
+#define portPRIORITY_GROUP_MASK					( 0x07UL << 8UL )
+#define portPRIGROUP_SHIFT						( 8UL )
 
 /* Offsets in the stack to the parameters when inside the SVC handler. */
 #define portOFFSET_TO_PC						( 6 )
 
 /* For strict compliance with the Cortex-M spec the task start address should
-have bit-0 clear, as it is loaded into the PC on exit from an ISR. */
-#define portSTART_ADDRESS_MASK				( ( StackType_t ) 0xfffffffeUL )
+ * have bit-0 clear, as it is loaded into the PC on exit from an ISR. */
+#define portSTART_ADDRESS_MASK					( ( StackType_t ) 0xfffffffeUL )
+/*-----------------------------------------------------------*/
 
 /*
  * Configure a number of standard MPU regions that are used by all tasks.
@@ -171,8 +172,8 @@ extern void vPortResetPrivilege( BaseType_t xRunningPrivileged );
 /*-----------------------------------------------------------*/
 
 /* Each task maintains its own interrupt status in the critical nesting
-variable.  Note this is not saved as part of the task context as context
-switches can only occur when uxCriticalNesting is zero. */
+ * variable.  Note this is not saved as part of the task context as context
+ * switches can only occur when uxCriticalNesting is zero. */
 static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
 
 /*
@@ -185,7 +186,6 @@ static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
 	 static uint32_t ulMaxPRIGROUPValue = 0;
 	 static const volatile uint8_t * const pcInterruptPriorityRegisters = ( const volatile uint8_t * const ) portNVIC_IP_REGISTERS_OFFSET_16;
 #endif /* configASSERT_DEFINED */
-
 /*-----------------------------------------------------------*/
 
 /*
@@ -194,7 +194,7 @@ static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
 StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters, BaseType_t xRunPrivileged )
 {
 	/* Simulate the stack frame as it would be created by a context switch
-	interrupt. */
+	 * interrupt. */
 	pxTopOfStack--; /* Offset added to account for the way the MCU uses the stack on entry/exit of interrupts. */
 	*pxTopOfStack = portINITIAL_XPSR;	/* xPSR */
 	pxTopOfStack--;
@@ -240,10 +240,25 @@ void vPortSVCHandler( void )
 static void prvSVCHandler(	uint32_t *pulParam )
 {
 uint8_t ucSVCNumber;
+uint32_t ulPC;
+#if( configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY == 1 )
+	#if defined( __ARMCC_VERSION )
+		/* Declaration when these variable are defined in code instead of being
+		 * exported from linker scripts. */
+		extern uint32_t * __syscalls_flash_start__;
+		extern uint32_t * __syscalls_flash_end__;
+	#else
+		/* Declaration when these variable are exported from linker scripts. */
+		extern uint32_t __syscalls_flash_start__[];
+		extern uint32_t __syscalls_flash_end__[];
+	#endif /* #if defined( __ARMCC_VERSION ) */
+#endif /* #if( configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY == 1 ) */
 
-	/* The stack contains: r0, r1, r2, r3, r12, r14, the return address and
-	xPSR.  The first argument (r0) is pulParam[ 0 ]. */
-	ucSVCNumber = ( ( uint8_t * ) pulParam[ portOFFSET_TO_PC ] )[ -2 ];
+	/* The stack contains: r0, r1, r2, r3, r12, LR, PC and xPSR.  The first
+	 * argument (r0) is pulParam[ 0 ]. */
+	ulPC = pulParam[ portOFFSET_TO_PC ];
+	ucSVCNumber = ( ( uint8_t * ) ulPC )[ -2 ];
+
 	switch( ucSVCNumber )
 	{
 		case portSVC_START_SCHEDULER	:	portNVIC_SYSPRI1_REG |= portNVIC_SVC_PRI;
@@ -252,14 +267,32 @@ uint8_t ucSVCNumber;
 
 		case portSVC_YIELD				:	portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
 											/* Barriers are normally not required
-											but do ensure the code is completely
-											within the specified behaviour for the
-											architecture. */
+											 * but do ensure the code is completely
+											 * within the specified behaviour for the
+											 * architecture. */
 											__asm volatile( "dsb" ::: "memory" );
 											__asm volatile( "isb" );
 
 											break;
 
+
+	#if( configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY == 1 )
+		case portSVC_RAISE_PRIVILEGE	:	/* Only raise the privilege, if the
+											 * svc was raised from any of the
+											 * system calls. */
+											if( ulPC >= ( uint32_t ) __syscalls_flash_start__ &&
+												ulPC <= ( uint32_t ) __syscalls_flash_end__ )
+											{
+												__asm volatile
+												(
+													"	mrs r1, control		\n" /* Obtain current control value. */
+													"	bic r1, #1			\n" /* Set privilege bit. */
+													"	msr control, r1		\n" /* Write back new control value. */
+													::: "r1", "memory"
+												);
+											}
+											break;
+	#else
 		case portSVC_RAISE_PRIVILEGE	:	__asm volatile
 											(
 												"	mrs r1, control		\n" /* Obtain current control value. */
@@ -268,6 +301,7 @@ uint8_t ucSVCNumber;
 												::: "r1", "memory"
 											);
 											break;
+	#endif /* #if( configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY == 1 ) */
 
 		default							:	/* Unknown SVC call. */
 											break;
@@ -287,9 +321,23 @@ static void prvRestoreContextOfFirstTask( void )
 		"	ldr r1, [r3]					\n"
 		"	ldr r0, [r1]					\n" /* The first item in the TCB is the task top of stack. */
 		"	add r1, r1, #4					\n" /* Move onto the second item in the TCB... */
+		"									\n"
+		"	dmb								\n" /* Complete outstanding transfers before disabling MPU. */
+		"	ldr r2, =0xe000ed94				\n" /* MPU_CTRL register. */
+		"	ldr r3, [r2]					\n" /* Read the value of MPU_CTRL. */
+		"	bic r3, #1						\n" /* r3 = r3 & ~1 i.e. Clear the bit 0 in r3. */
+		"	str r3, [r2]					\n" /* Disable MPU. */
+		"									\n"
 		"	ldr r2, =0xe000ed9c				\n" /* Region Base Address register. */
 		"	ldmia r1!, {r4-r11}				\n" /* Read 4 sets of MPU registers. */
 		"	stmia r2!, {r4-r11}				\n" /* Write 4 sets of MPU registers. */
+		"									\n"
+		"	ldr r2, =0xe000ed94				\n" /* MPU_CTRL register. */
+		"	ldr r3, [r2]					\n" /* Read the value of MPU_CTRL. */
+		"	orr r3, #1						\n" /* r3 = r3 | 1 i.e. Set the bit 0 in r3. */
+		"	str r3, [r2]					\n" /* Enable MPU. */
+		"	dsb								\n" /* Force memory writes before continuing. */
+		"									\n"
 		"	ldmia r0!, {r3, r4-r11}			\n" /* Pop the registers that are not automatically saved on exception entry. */
 		"	msr control, r3					\n"
 		"	msr psp, r0						\n" /* Restore the task stack pointer. */
@@ -310,7 +358,7 @@ static void prvRestoreContextOfFirstTask( void )
 BaseType_t xPortStartScheduler( void )
 {
 	/* configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to 0.  See
-	http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
+	 * http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
 	configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) );
 
 	#if( configASSERT_DEFINED == 1 )
@@ -320,15 +368,15 @@ BaseType_t xPortStartScheduler( void )
 		volatile uint8_t ucMaxPriorityValue;
 
 		/* Determine the maximum priority from which ISR safe FreeRTOS API
-		functions can be called.  ISR safe functions are those that end in
-		"FromISR".  FreeRTOS maintains separate thread and ISR API functions to
-		ensure interrupt entry is as fast and simple as possible.
+		 * functions can be called.  ISR safe functions are those that end in
+		 * "FromISR".  FreeRTOS maintains separate thread and ISR API functions
+		 * to ensure interrupt entry is as fast and simple as possible.
 
-		Save the interrupt priority value that is about to be clobbered. */
+		 * Save the interrupt priority value that is about to be clobbered. */
 		ulOriginalPriority = *pucFirstUserPriorityRegister;
 
 		/* Determine the number of priority bits available.  First write to all
-		possible bits. */
+		 * possible bits. */
 		*pucFirstUserPriorityRegister = portMAX_8_BIT_VALUE;
 
 		/* Read the value back to see how many bits stuck. */
@@ -338,7 +386,7 @@ BaseType_t xPortStartScheduler( void )
 		ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
 
 		/* Calculate the maximum acceptable priority group value for the number
-		of bits read back. */
+		 * of bits read back. */
 		ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS;
 		while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
 		{
@@ -349,8 +397,8 @@ BaseType_t xPortStartScheduler( void )
 		#ifdef __NVIC_PRIO_BITS
 		{
 			/* Check the CMSIS configuration that defines the number of
-			priority bits matches the number of priority bits actually queried
-			from the hardware. */
+			 * priority bits matches the number of priority bits actually queried
+			 * from the hardware. */
 			configASSERT( ( portMAX_PRIGROUP_BITS - ulMaxPRIGROUPValue ) == __NVIC_PRIO_BITS );
 		}
 		#endif
@@ -358,26 +406,26 @@ BaseType_t xPortStartScheduler( void )
 		#ifdef configPRIO_BITS
 		{
 			/* Check the FreeRTOS configuration that defines the number of
-			priority bits matches the number of priority bits actually queried
-			from the hardware. */
+			 * priority bits matches the number of priority bits actually queried
+			 * from the hardware. */
 			configASSERT( ( portMAX_PRIGROUP_BITS - ulMaxPRIGROUPValue ) == configPRIO_BITS );
 		}
 		#endif
 
 		/* Shift the priority group value back to its position within the AIRCR
-		register. */
+		 * register. */
 		ulMaxPRIGROUPValue <<= portPRIGROUP_SHIFT;
 		ulMaxPRIGROUPValue &= portPRIORITY_GROUP_MASK;
 
 		/* Restore the clobbered interrupt priority register to its original
-		value. */
+		 * value. */
 		*pucFirstUserPriorityRegister = ulOriginalPriority;
 	}
 	#endif /* conifgASSERT_DEFINED */
 
 	/* Make PendSV and SysTick the same priority as the kernel, and the SVC
-	handler higher priority so it can be used to exit a critical section (where
-	lower priorities are masked). */
+	 * handler higher priority so it can be used to exit a critical section (where
+	 * lower priorities are masked). */
 	portNVIC_SYSPRI2_REG |= portNVIC_PENDSV_PRI;
 	portNVIC_SYSPRI2_REG |= portNVIC_SYSTICK_PRI;
 
@@ -385,7 +433,7 @@ BaseType_t xPortStartScheduler( void )
 	prvSetupMPU();
 
 	/* Start the timer that generates the tick ISR.  Interrupts are disabled
-	here already. */
+	 * here already. */
 	vPortSetupTimerInterrupt();
 
 	/* Initialise the critical nesting count ready for the first task. */
@@ -413,7 +461,7 @@ BaseType_t xPortStartScheduler( void )
 void vPortEndScheduler( void )
 {
 	/* Not implemented in ports where there is nothing to return to.
-	Artificially force an assert. */
+	 * Artificially force an assert. */
 	configASSERT( uxCriticalNesting == 1000UL );
 }
 /*-----------------------------------------------------------*/
@@ -471,9 +519,23 @@ void xPortPendSVHandler( void )
 		"	ldr r1, [r3]						\n"
 		"	ldr r0, [r1]						\n" /* The first item in the TCB is the task top of stack. */
 		"	add r1, r1, #4						\n" /* Move onto the second item in the TCB... */
+		"										\n"
+		"	dmb									\n" /* Complete outstanding transfers before disabling MPU. */
+		"	ldr r2, =0xe000ed94					\n" /* MPU_CTRL register. */
+		"	ldr r3, [r2]						\n" /* Read the value of MPU_CTRL. */
+		"	bic r3, #1							\n" /* r3 = r3 & ~1 i.e. Clear the bit 0 in r3. */
+		"	str r3, [r2]						\n" /* Disable MPU. */
+		"										\n"
 		"	ldr r2, =0xe000ed9c					\n" /* Region Base Address register. */
 		"	ldmia r1!, {r4-r11}					\n" /* Read 4 sets of MPU registers. */
 		"	stmia r2!, {r4-r11}					\n" /* Write 4 sets of MPU registers. */
+		"										\n"
+		"	ldr r2, =0xe000ed94					\n" /* MPU_CTRL register. */
+		"	ldr r3, [r2]						\n" /* Read the value of MPU_CTRL. */
+		"	orr r3, #1							\n" /* r3 = r3 | 1 i.e. Set the bit 0 in r3. */
+		"	str r3, [r2]						\n" /* Enable MPU. */
+		"	dsb									\n" /* Force memory writes before continuing. */
+		"										\n"
 		"	ldmia r0!, {r3, r4-r11}				\n" /* Pop the registers that are not automatically saved on exception entry. */
 		"	msr control, r3						\n"
 		"										\n"
@@ -542,8 +604,8 @@ extern uint32_t __privileged_data_end__[];
 										( portMPU_REGION_ENABLE );
 
 		/* Setup the first 16K for privileged only access (even though less
-		than 10K is actually being used).  This is where the kernel code is
-		placed. */
+		 * than 10K is actually being used).  This is where the kernel code is
+		 * placed. */
 		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __FLASH_segment_start__ ) | /* Base address. */
 											( portMPU_REGION_VALID ) |
 											( portPRIVILEGED_FLASH_REGION );
@@ -554,7 +616,7 @@ extern uint32_t __privileged_data_end__[];
 										( portMPU_REGION_ENABLE );
 
 		/* Setup the privileged data RAM region.  This is where the kernel data
-		is placed. */
+		 * is placed. */
 		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __privileged_data_start__ ) | /* Base address. */
 											( portMPU_REGION_VALID ) |
 											( portPRIVILEGED_RAM_REGION );
@@ -565,7 +627,7 @@ extern uint32_t __privileged_data_end__[];
 										( portMPU_REGION_ENABLE );
 
 		/* By default allow everything to access the general peripherals.  The
-		system peripherals and registers are protected. */
+		 * system peripherals and registers are protected. */
 		portMPU_REGION_BASE_ADDRESS_REG =	( portPERIPHERALS_START_ADDRESS ) |
 											( portMPU_REGION_VALID ) |
 											( portGENERAL_PERIPHERALS_REGION );
@@ -588,7 +650,7 @@ static uint32_t prvGetMPURegionSizeSetting( uint32_t ulActualSizeInBytes )
 uint32_t ulRegionSize, ulReturnValue = 4;
 
 	/* 32 is the smallest region size, 31 is the largest valid value for
-	ulReturnValue. */
+	 * ulReturnValue. */
 	for( ulRegionSize = 32UL; ulReturnValue < 31UL; ( ulRegionSize <<= 1UL ) )
 	{
 		if( ulActualSizeInBytes <= ulRegionSize )
@@ -602,7 +664,7 @@ uint32_t ulRegionSize, ulReturnValue = 4;
 	}
 
 	/* Shift the code by one before returning so it can be written directly
-	into the the correct bit position of the attribute register. */
+	 * into the the correct bit position of the attribute register. */
 	return ( ulReturnValue << 1UL );
 }
 /*-----------------------------------------------------------*/
@@ -661,7 +723,7 @@ uint32_t ul;
 				( portMPU_REGION_ENABLE );
 
 		/* Re-instate the privileged only RAM region as xRegion[ 0 ] will have
-		just removed the privileged only parameters. */
+		 * just removed the privileged only parameters. */
 		xMPUSettings->xRegion[ 1 ].ulRegionBaseAddress =
 				( ( uint32_t ) __privileged_data_start__ ) | /* Base address. */
 				( portMPU_REGION_VALID ) |
@@ -683,9 +745,9 @@ uint32_t ul;
 	else
 	{
 		/* This function is called automatically when the task is created - in
-		which case the stack region parameters will be valid.  At all other
-		times the stack parameters will not be valid and it is assumed that the
-		stack region has already been configured. */
+		 * which case the stack region parameters will be valid.  At all other
+		 * times the stack parameters will not be valid and it is assumed that the
+		 * stack region has already been configured. */
 		if( ulStackDepth > 0 )
 		{
 			/* Define the region that allows access to the stack. */
@@ -708,8 +770,8 @@ uint32_t ul;
 			if( ( xRegions[ lIndex ] ).ulLengthInBytes > 0UL )
 			{
 				/* Translate the generic region definition contained in
-				xRegions into the CM3 specific MPU settings that are then
-				stored in xMPUSettings. */
+				 * xRegions into the CM3 specific MPU settings that are then
+				 * stored in xMPUSettings. */
 				xMPUSettings->xRegion[ ul ].ulRegionBaseAddress =
 						( ( uint32_t ) xRegions[ lIndex ].pvBaseAddress ) |
 						( portMPU_REGION_VALID ) |
@@ -750,48 +812,46 @@ uint32_t ul;
 			ucCurrentPriority = pcInterruptPriorityRegisters[ ulCurrentInterrupt ];
 
 			/* The following assertion will fail if a service routine (ISR) for
-			an interrupt that has been assigned a priority above
-			configMAX_SYSCALL_INTERRUPT_PRIORITY calls an ISR safe FreeRTOS API
-			function.  ISR safe FreeRTOS API functions must *only* be called
-			from interrupts that have been assigned a priority at or below
-			configMAX_SYSCALL_INTERRUPT_PRIORITY.
+			 * an interrupt that has been assigned a priority above
+			 * configMAX_SYSCALL_INTERRUPT_PRIORITY calls an ISR safe FreeRTOS API
+			 * function.  ISR safe FreeRTOS API functions must *only* be called
+			 * from interrupts that have been assigned a priority at or below
+			 * configMAX_SYSCALL_INTERRUPT_PRIORITY.
 
-			Numerically low interrupt priority numbers represent logically high
-			interrupt priorities, therefore the priority of the interrupt must
-			be set to a value equal to or numerically *higher* than
-			configMAX_SYSCALL_INTERRUPT_PRIORITY.
+			 * Numerically low interrupt priority numbers represent logically high
+			 * interrupt priorities, therefore the priority of the interrupt must
+			 * be set to a value equal to or numerically *higher* than
+			 * configMAX_SYSCALL_INTERRUPT_PRIORITY.
 
-			Interrupts that	use the FreeRTOS API must not be left at their
-			default priority of	zero as that is the highest possible priority,
-			which is guaranteed to be above configMAX_SYSCALL_INTERRUPT_PRIORITY,
-			and	therefore also guaranteed to be invalid.
+			 * Interrupts that	use the FreeRTOS API must not be left at their
+			 * default priority of	zero as that is the highest possible priority,
+			 * which is guaranteed to be above configMAX_SYSCALL_INTERRUPT_PRIORITY,
+			 * and	therefore also guaranteed to be invalid.
 
-			FreeRTOS maintains separate thread and ISR API functions to ensure
-			interrupt entry is as fast and simple as possible.
+			 * FreeRTOS maintains separate thread and ISR API functions to ensure
+			 * interrupt entry is as fast and simple as possible.
 
-			The following links provide detailed information:
-			http://www.freertos.org/RTOS-Cortex-M3-M4.html
-			http://www.freertos.org/FAQHelp.html */
+			 * The following links provide detailed information:
+			 * http://www.freertos.org/RTOS-Cortex-M3-M4.html
+			 * http://www.freertos.org/FAQHelp.html */
 			configASSERT( ucCurrentPriority >= ucMaxSysCallPriority );
 		}
 
 		/* Priority grouping:  The interrupt controller (NVIC) allows the bits
-		that define each interrupt's priority to be split between bits that
-		define the interrupt's pre-emption priority bits and bits that define
-		the interrupt's sub-priority.  For simplicity all bits must be defined
-		to be pre-emption priority bits.  The following assertion will fail if
-		this is not the case (if some bits represent a sub-priority).
+		 * that define each interrupt's priority to be split between bits that
+		 * define the interrupt's pre-emption priority bits and bits that define
+		 * the interrupt's sub-priority.  For simplicity all bits must be defined
+		 * to be pre-emption priority bits.  The following assertion will fail if
+		 * this is not the case (if some bits represent a sub-priority).
 
-		If the application only uses CMSIS libraries for interrupt
-		configuration then the correct setting can be achieved on all Cortex-M
-		devices by calling NVIC_SetPriorityGrouping( 0 ); before starting the
-		scheduler.  Note however that some vendor specific peripheral libraries
-		assume a non-zero priority group setting, in which cases using a value
-		of zero will result in unpredicable behaviour. */
+		 * If the application only uses CMSIS libraries for interrupt
+		 * configuration then the correct setting can be achieved on all Cortex-M
+		 * devices by calling NVIC_SetPriorityGrouping( 0 ); before starting the
+		 * scheduler.  Note however that some vendor specific peripheral libraries
+		 * assume a non-zero priority group setting, in which cases using a value
+		 * of zero will result in unpredicable behaviour. */
 		configASSERT( ( portAIRCR_REG & portPRIORITY_GROUP_MASK ) <= ulMaxPRIGROUPValue );
 	}
 
 #endif /* configASSERT_DEFINED */
 /*-----------------------------------------------------------*/
-
-

--- a/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -73,12 +73,13 @@ typedef unsigned long UBaseType_t;
 #define portUSING_MPU_WRAPPERS		1
 #define portPRIVILEGE_BIT			( 0x80000000UL )
 
-#define portMPU_REGION_READ_WRITE				( 0x03UL << 24UL )
-#define portMPU_REGION_PRIVILEGED_READ_ONLY		( 0x05UL << 24UL )
-#define portMPU_REGION_READ_ONLY				( 0x06UL << 24UL )
-#define portMPU_REGION_PRIVILEGED_READ_WRITE	( 0x01UL << 24UL )
-#define portMPU_REGION_CACHEABLE_BUFFERABLE		( 0x07UL << 16UL )
-#define portMPU_REGION_EXECUTE_NEVER			( 0x01UL << 28UL )
+#define portMPU_REGION_READ_WRITE								( 0x03UL << 24UL )
+#define portMPU_REGION_PRIVILEGED_READ_ONLY						( 0x05UL << 24UL )
+#define portMPU_REGION_READ_ONLY								( 0x06UL << 24UL )
+#define portMPU_REGION_PRIVILEGED_READ_WRITE					( 0x01UL << 24UL )
+#define portMPU_REGION_PRIVILEGED_READ_WRITE_UNPRIV_READ_ONLY	( 0x02UL << 24UL )
+#define portMPU_REGION_CACHEABLE_BUFFERABLE						( 0x07UL << 16UL )
+#define portMPU_REGION_EXECUTE_NEVER							( 0x01UL << 28UL )
 
 #define portUNPRIVILEGED_FLASH_REGION		( 0UL )
 #define portPRIVILEGED_FLASH_REGION			( 1UL )
@@ -293,6 +294,11 @@ portFORCE_INLINE static void vPortSetBASEPRI( uint32_t ulNewMaskValue )
 
 #define portMEMORY_BARRIER() __asm volatile( "" ::: "memory" )
 
+#ifndef configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY
+	#warning "configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY is not defined. We recommend defining it to 1 in FreeRTOSConfig.h for better security. https://www.freertos.org/FreeRTOS-V10.3.x.html"
+	#define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY 0
+#endif
+/*-----------------------------------------------------------*/
 #ifdef __cplusplus
 }
 #endif

--- a/portable/GCC/ARM_CM4F/port.c
+++ b/portable/GCC/ARM_CM4F/port.c
@@ -277,6 +277,7 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg 				\n" /* Ensure the pool is placed here, so ldr doesn't generate a too long jump */
 				);
 }
 /*-----------------------------------------------------------*/
@@ -707,7 +708,8 @@ static void vPortEnableVFP( void )
 		"								\n"
 		"	orr r1, r1, #( 0xf << 20 )	\n" /* Enable CP10 and CP11 coprocessors, then save back. */
 		"	str r1, [r0]				\n"
-		"	bx r14						"
+		"	bx r14						\n"
+		"	.ltorg 				\n" /* Ensure the pool is placed here, so ldr doesn't generate a too long jump */
 	);
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM4F/port.c
+++ b/portable/GCC/ARM_CM4F/port.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -277,7 +277,6 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
-					" .ltorg 				\n" /* Ensure the pool is placed here, so ldr doesn't generate a too long jump */
 				);
 }
 /*-----------------------------------------------------------*/
@@ -577,14 +576,14 @@ void xPortSysTickHandler( void )
 			should not be executed again.  However, the original expected idle
 			time variable must remain unmodified, so a copy is taken. */
 			xModifiableIdleTime = xExpectedIdleTime;
-			configPRE_SLEEP_PROCESSING( &xModifiableIdleTime );
+			configPRE_SLEEP_PROCESSING( xModifiableIdleTime );
 			if( xModifiableIdleTime > 0 )
 			{
 				__asm volatile( "dsb" ::: "memory" );
 				__asm volatile( "wfi" );
 				__asm volatile( "isb" );
 			}
-			configPOST_SLEEP_PROCESSING( &xExpectedIdleTime );
+			configPOST_SLEEP_PROCESSING( xExpectedIdleTime );
 
 			/* Re-enable interrupts to allow the interrupt that brought the MCU
 			out of sleep mode to execute immediately.  see comments above
@@ -665,7 +664,7 @@ void xPortSysTickHandler( void )
 			vTaskStepTick( ulCompleteTickPeriods );
 			portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
 
-			/* Exit with interrpts enabled. */
+			/* Exit with interrupts enabled. */
 			__asm volatile( "cpsie i" ::: "memory" );
 		}
 	}
@@ -708,8 +707,7 @@ static void vPortEnableVFP( void )
 		"								\n"
 		"	orr r1, r1, #( 0xf << 20 )	\n" /* Enable CP10 and CP11 coprocessors, then save back. */
 		"	str r1, [r0]				\n"
-		"	bx r14						\n"
-		"	.ltorg 				\n" /* Ensure the pool is placed here, so ldr doesn't generate a too long jump */
+		"	bx r14						"
 	);
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM4F/portmacro.h
+++ b/portable/GCC/ARM_CM4F/portmacro.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -134,7 +134,7 @@ void vPortSetupTimerInterrupt( void );
  * Standard FreeRTOS exception handlers.
  */
 void xPortPendSVHandler( void ) __attribute__ (( naked )) PRIVILEGED_FUNCTION;
-void xPortSysTickHandler( void )  __attribute__ ((optimize("3"))) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 void vPortSVCHandler( void ) __attribute__ (( naked )) PRIVILEGED_FUNCTION;
 
 /*
@@ -260,10 +260,25 @@ void vPortSVCHandler( void )
 static void prvSVCHandler(	uint32_t *pulParam )
 {
 uint8_t ucSVCNumber;
+uint32_t ulPC;
+#if( configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY == 1 )
+	#if defined( __ARMCC_VERSION )
+		/* Declaration when these variable are defined in code instead of being
+		* exported from linker scripts. */
+		extern uint32_t * __syscalls_flash_start__;
+		extern uint32_t * __syscalls_flash_end__;
+	#else
+		/* Declaration when these variable are exported from linker scripts. */
+		extern uint32_t __syscalls_flash_start__[];
+		extern uint32_t __syscalls_flash_end__[];
+	#endif /* #if defined( __ARMCC_VERSION ) */
+#endif /* #if( configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY == 1 ) */
 
-	/* The stack contains: r0, r1, r2, r3, r12, r14, the return address and
-	xPSR.  The first argument (r0) is pulParam[ 0 ]. */
-	ucSVCNumber = ( ( uint8_t * ) pulParam[ portOFFSET_TO_PC ] )[ -2 ];
+	/* The stack contains: r0, r1, r2, r3, r12, LR, PC and xPSR.  The first
+	argument (r0) is pulParam[ 0 ]. */
+	ulPC = pulParam[ portOFFSET_TO_PC ];
+	ucSVCNumber = ( ( uint8_t * ) ulPC )[ -2 ];
+
 	switch( ucSVCNumber )
 	{
 		case portSVC_START_SCHEDULER	:	portNVIC_SYSPRI1_REG |= portNVIC_SVC_PRI;
@@ -280,6 +295,23 @@ uint8_t ucSVCNumber;
 
 											break;
 
+	#if( configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY == 1 )
+		case portSVC_RAISE_PRIVILEGE	:	/* Only raise the privilege, if the
+											 * svc was raised from any of the
+											 * system calls. */
+											if( ulPC >= ( uint32_t ) __syscalls_flash_start__ &&
+												ulPC <= ( uint32_t ) __syscalls_flash_end__ )
+											{
+												__asm volatile
+												(
+													"	mrs r1, control		\n" /* Obtain current control value. */
+													"	bic r1, #1			\n" /* Set privilege bit. */
+													"	msr control, r1		\n" /* Write back new control value. */
+													::: "r1", "memory"
+												);
+											}
+											break;
+	#else
 		case portSVC_RAISE_PRIVILEGE	:	__asm volatile
 											(
 												"	mrs r1, control		\n" /* Obtain current control value. */
@@ -288,6 +320,7 @@ uint8_t ucSVCNumber;
 												::: "r1", "memory"
 											);
 											break;
+	#endif /* #if( configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY == 1 ) */
 
 		default							:	/* Unknown SVC call. */
 											break;
@@ -307,9 +340,23 @@ static void prvRestoreContextOfFirstTask( void )
 		"	ldr r1, [r3]					\n"
 		"	ldr r0, [r1]					\n" /* The first item in the TCB is the task top of stack. */
 		"	add r1, r1, #4					\n" /* Move onto the second item in the TCB... */
+		"									\n"
+		"	dmb								\n" /* Complete outstanding transfers before disabling MPU. */
+		"	ldr r2, =0xe000ed94				\n" /* MPU_CTRL register. */
+		"	ldr r3, [r2]					\n" /* Read the value of MPU_CTRL. */
+		"	bic r3, #1						\n" /* r3 = r3 & ~1 i.e. Clear the bit 0 in r3. */
+		"	str r3, [r2]					\n" /* Disable MPU. */
+		"									\n"
 		"	ldr r2, =0xe000ed9c				\n" /* Region Base Address register. */
-		"	ldmia r1!, {r4-r11}				\n" /* Read 4 sets of MPU registers. */
+		"	ldmia r1!, {r4-r11}				\n" /* Read 4 sets of MPU registers from TCB. */
 		"	stmia r2!, {r4-r11}				\n" /* Write 4 sets of MPU registers. */
+		"									\n"
+		"	ldr r2, =0xe000ed94				\n" /* MPU_CTRL register. */
+		"	ldr r3, [r2]					\n" /* Read the value of MPU_CTRL. */
+		"	orr r3, #1						\n" /* r3 = r3 | 1 i.e. Set the bit 0 in r3. */
+		"	str r3, [r2]					\n" /* Enable MPU. */
+		"	dsb								\n" /* Force memory writes before continuing. */
+		"									\n"
 		"	ldmia r0!, {r3-r11, r14}		\n" /* Pop the registers that are not automatically saved on exception entry. */
 		"	msr control, r3					\n"
 		"	msr psp, r0						\n" /* Restore the task stack pointer. */
@@ -506,9 +553,23 @@ void xPortPendSVHandler( void )
 		"	ldr r1, [r3]						\n"
 		"	ldr r0, [r1]						\n" /* The first item in the TCB is the task top of stack. */
 		"	add r1, r1, #4						\n" /* Move onto the second item in the TCB... */
+		"										\n"
+		"	dmb									\n" /* Complete outstanding transfers before disabling MPU. */
+		"	ldr r2, =0xe000ed94					\n" /* MPU_CTRL register. */
+		"	ldr r3, [r2]						\n" /* Read the value of MPU_CTRL. */
+		"	bic r3, #1							\n" /* r3 = r3 & ~1 i.e. Clear the bit 0 in r3. */
+		"	str r3, [r2]						\n" /* Disable MPU. */
+		"										\n"
 		"	ldr r2, =0xe000ed9c					\n" /* Region Base Address register. */
-		"	ldmia r1!, {r4-r11}					\n" /* Read 4 sets of MPU registers. */
+		"	ldmia r1!, {r4-r11}					\n" /* Read 4 sets of MPU registers from TCB. */
 		"	stmia r2!, {r4-r11}					\n" /* Write 4 sets of MPU registers. */
+		"										\n"
+		"	ldr r2, =0xe000ed94					\n" /* MPU_CTRL register. */
+		"	ldr r3, [r2]						\n" /* Read the value of MPU_CTRL. */
+		"	orr r3, #1							\n" /* r3 = r3 | 1 i.e. Set the bit 0 in r3. */
+		"	str r3, [r2]						\n" /* Enable MPU. */
+		"	dsb									\n" /* Force memory writes before continuing. */
+		"										\n"
 		"	ldmia r0!, {r3-r11, r14}			\n" /* Pop the registers that are not automatically saved on exception entry. */
 		"	msr control, r3						\n"
 		"										\n"
@@ -576,14 +637,24 @@ static void vPortEnableVFP( void )
 
 static void prvSetupMPU( void )
 {
-extern uint32_t __privileged_functions_end__[];
-extern uint32_t __FLASH_segment_start__[];
-extern uint32_t __FLASH_segment_end__[];
-extern uint32_t __privileged_data_start__[];
-extern uint32_t __privileged_data_end__[];
-
+#if defined( __ARMCC_VERSION )
+	/* Declaration when these variable are defined in code instead of being
+	 * exported from linker scripts. */
+	extern uint32_t * __privileged_functions_end__;
+	extern uint32_t * __FLASH_segment_start__;
+	extern uint32_t * __FLASH_segment_end__;
+	extern uint32_t * __privileged_data_start__;
+	extern uint32_t * __privileged_data_end__;
+#else
+	/* Declaration when these variable are exported from linker scripts. */
+	extern uint32_t __privileged_functions_end__[];
+	extern uint32_t __FLASH_segment_start__[];
+	extern uint32_t __FLASH_segment_end__[];
+	extern uint32_t __privileged_data_start__[];
+	extern uint32_t __privileged_data_end__[];
+#endif
 	/* Check the expected MPU is present. */
-	if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
+	if( ( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )  || ( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE << 1 ))
 	{
 		/* First setup the entire flash for unprivileged read only access. */
 		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __FLASH_segment_start__ ) | /* Base address. */
@@ -693,10 +764,21 @@ void vResetPrivilege( void ) /* __attribute__ (( naked )) */
 
 void vPortStoreTaskMPUSettings( xMPU_SETTINGS *xMPUSettings, const struct xMEMORY_REGION * const xRegions, StackType_t *pxBottomOfStack, uint32_t ulStackDepth )
 {
-extern uint32_t __SRAM_segment_start__[];
-extern uint32_t __SRAM_segment_end__[];
-extern uint32_t __privileged_data_start__[];
-extern uint32_t __privileged_data_end__[];
+#if defined( __ARMCC_VERSION )
+	/* Declaration when these variable are defined in code instead of being
+	 * exported from linker scripts. */
+	extern uint32_t * __SRAM_segment_start__;
+	extern uint32_t * __SRAM_segment_end__;
+	extern uint32_t * __privileged_data_start__;
+	extern uint32_t * __privileged_data_end__;
+#else
+	/* Declaration when these variable are exported from linker scripts. */
+	extern uint32_t __SRAM_segment_start__[];
+	extern uint32_t __SRAM_segment_end__[];
+	extern uint32_t __privileged_data_start__[];
+	extern uint32_t __privileged_data_end__[];
+#endif
+
 int32_t lIndex;
 uint32_t ul;
 

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -73,12 +73,13 @@ typedef unsigned long UBaseType_t;
 #define portUSING_MPU_WRAPPERS		1
 #define portPRIVILEGE_BIT			( 0x80000000UL )
 
-#define portMPU_REGION_READ_WRITE				( 0x03UL << 24UL )
-#define portMPU_REGION_PRIVILEGED_READ_ONLY		( 0x05UL << 24UL )
-#define portMPU_REGION_READ_ONLY				( 0x06UL << 24UL )
-#define portMPU_REGION_PRIVILEGED_READ_WRITE	( 0x01UL << 24UL )
-#define portMPU_REGION_CACHEABLE_BUFFERABLE		( 0x07UL << 16UL )
-#define portMPU_REGION_EXECUTE_NEVER			( 0x01UL << 28UL )
+#define portMPU_REGION_READ_WRITE								( 0x03UL << 24UL )
+#define portMPU_REGION_PRIVILEGED_READ_ONLY						( 0x05UL << 24UL )
+#define portMPU_REGION_READ_ONLY								( 0x06UL << 24UL )
+#define portMPU_REGION_PRIVILEGED_READ_WRITE					( 0x01UL << 24UL )
+#define portMPU_REGION_PRIVILEGED_READ_WRITE_UNPRIV_READ_ONLY	( 0x02UL << 24UL )
+#define portMPU_REGION_CACHEABLE_BUFFERABLE						( 0x03UL << 16UL )
+#define portMPU_REGION_EXECUTE_NEVER							( 0x01UL << 28UL )
 
 #define portUNPRIVILEGED_FLASH_REGION		( 0UL )
 #define portPRIVILEGED_FLASH_REGION			( 1UL )
@@ -293,6 +294,11 @@ portFORCE_INLINE static void vPortSetBASEPRI( uint32_t ulNewMaskValue )
 
 #define portMEMORY_BARRIER() __asm volatile( "" ::: "memory" )
 
+#ifndef configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY
+	#warning "configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY is not defined. We recommend defining it to 1 in FreeRTOSConfig.h for better security. https://www.freertos.org/FreeRTOS-V10.3.x.html"
+	#define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY 0
+#endif
+/*-----------------------------------------------------------*/
 #ifdef __cplusplus
 }
 #endif

--- a/portable/GCC/ARM_CM7/r0p1/port.c
+++ b/portable/GCC/ARM_CM7/r0p1/port.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -271,7 +271,6 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
-					" .ltorg 				\n" /* Ensure the pool is placed here, so ldr doesn't generate a too long jump */
 				);
 }
 /*-----------------------------------------------------------*/
@@ -567,14 +566,14 @@ void xPortSysTickHandler( void )
 			should not be executed again.  However, the original expected idle
 			time variable must remain unmodified, so a copy is taken. */
 			xModifiableIdleTime = xExpectedIdleTime;
-			configPRE_SLEEP_PROCESSING( &xModifiableIdleTime );
+			configPRE_SLEEP_PROCESSING( xModifiableIdleTime );
 			if( xModifiableIdleTime > 0 )
 			{
 				__asm volatile( "dsb" ::: "memory" );
 				__asm volatile( "wfi" );
 				__asm volatile( "isb" );
 			}
-			configPOST_SLEEP_PROCESSING( &xExpectedIdleTime );
+			configPOST_SLEEP_PROCESSING( xExpectedIdleTime );
 
 			/* Re-enable interrupts to allow the interrupt that brought the MCU
 			out of sleep mode to execute immediately.  see comments above
@@ -655,7 +654,7 @@ void xPortSysTickHandler( void )
 			vTaskStepTick( ulCompleteTickPeriods );
 			portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
 
-			/* Exit with interrpts enabled. */
+			/* Exit with interrupts enabled. */
 			__asm volatile( "cpsie i" ::: "memory" );
 		}
 	}
@@ -698,8 +697,7 @@ static void vPortEnableVFP( void )
 		"								\n"
 		"	orr r1, r1, #( 0xf << 20 )	\n" /* Enable CP10 and CP11 coprocessors, then save back. */
 		"	str r1, [r0]				\n"
-		"	bx r14						\n"
-		"	.ltorg 				\n" /* Ensure the pool is placed here, so ldr doesn't generate a too long jump */
+		"	bx r14						"
 	);
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM7/r0p1/port.c
+++ b/portable/GCC/ARM_CM7/r0p1/port.c
@@ -271,6 +271,7 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg 				\n" /* Ensure the pool is placed here, so ldr doesn't generate a too long jump */
 				);
 }
 /*-----------------------------------------------------------*/
@@ -697,7 +698,8 @@ static void vPortEnableVFP( void )
 		"								\n"
 		"	orr r1, r1, #( 0xf << 20 )	\n" /* Enable CP10 and CP11 coprocessors, then save back. */
 		"	str r1, [r0]				\n"
-		"	bx r14						"
+		"	bx r14						\n"
+		"	.ltorg 				\n" /* Ensure the pool is placed here, so ldr doesn't generate a too long jump */
 	);
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM7/r0p1/portmacro.h
+++ b/portable/GCC/ARM_CM7/r0p1/portmacro.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/GCC/ARM_CM7_MPU/r0p1/portmacro.h
+++ b/portable/GCC/ARM_CM7_MPU/r0p1/portmacro.h
@@ -1,6 +1,7 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Portion Copyright © 2020 STMicroelectronics International N.V. All rights reserved.
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -24,6 +25,7 @@
  *
  * 1 tab == 4 spaces!
  */
+
 
 #ifndef PORTMACRO_H
 #define PORTMACRO_H
@@ -72,12 +74,13 @@ typedef unsigned long UBaseType_t;
 #define portUSING_MPU_WRAPPERS		1
 #define portPRIVILEGE_BIT			( 0x80000000UL )
 
-#define portMPU_REGION_READ_WRITE				( 0x03UL << 24UL )
-#define portMPU_REGION_PRIVILEGED_READ_ONLY		( 0x05UL << 24UL )
-#define portMPU_REGION_READ_ONLY				( 0x06UL << 24UL )
-#define portMPU_REGION_PRIVILEGED_READ_WRITE	( 0x01UL << 24UL )
-#define portMPU_REGION_CACHEABLE_BUFFERABLE		( 0x07UL << 16UL )
-#define portMPU_REGION_EXECUTE_NEVER			( 0x01UL << 28UL )
+#define portMPU_REGION_READ_WRITE								( 0x03UL << 24UL )
+#define portMPU_REGION_PRIVILEGED_READ_ONLY						( 0x05UL << 24UL )
+#define portMPU_REGION_READ_ONLY								( 0x06UL << 24UL )
+#define portMPU_REGION_PRIVILEGED_READ_WRITE					( 0x01UL << 24UL )
+#define portMPU_REGION_PRIVILEGED_READ_WRITE_UNPRIV_READ_ONLY	( 0x02UL << 24UL )
+#define portMPU_REGION_CACHEABLE_BUFFERABLE						( 0x03UL << 16UL )
+#define portMPU_REGION_EXECUTE_NEVER							( 0x01UL << 28UL )
 
 #define portUNPRIVILEGED_FLASH_REGION		( 0UL )
 #define portPRIVILEGED_FLASH_REGION			( 1UL )
@@ -296,6 +299,11 @@ portFORCE_INLINE static void vPortSetBASEPRI( uint32_t ulNewMaskValue )
 
 #define portMEMORY_BARRIER() __asm volatile( "" ::: "memory" )
 
+#ifndef configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY
+	#warning "configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY is not defined. We recommend defining it to 1 in FreeRTOSConfig.h for better security. https://www.freertos.org/FreeRTOS-V10.3.x.html"
+	#define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY 0
+#endif
+/*-----------------------------------------------------------*/
 #ifdef __cplusplus
 }
 #endif

--- a/portable/MemMang/heap_1.c
+++ b/portable/MemMang/heap_1.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/MemMang/heap_2.c
+++ b/portable/MemMang/heap_2.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/MemMang/heap_3.c
+++ b/portable/MemMang/heap_3.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -97,10 +97,12 @@ static const size_t xHeapStructSize	= ( sizeof( BlockLink_t ) + ( ( size_t ) ( p
 /* Create a couple of list links to mark the start and end of the list. */
 static BlockLink_t xStart, *pxEnd = NULL;
 
-/* Keeps track of the number of free bytes remaining, but says nothing about
-fragmentation. */
+/* Keeps track of the number of calls to allocate and free memory as well as the
+number of free bytes remaining, but says nothing about fragmentation. */
 static size_t xFreeBytesRemaining = 0U;
 static size_t xMinimumEverFreeBytesRemaining = 0U;
+static size_t xNumberOfSuccessfulAllocations = 0;
+static size_t xNumberOfSuccessfulFrees = 0;
 
 /* Gets set to the top bit of an size_t type.  When this bit in the xBlockSize
 member of an BlockLink_t structure is set then the block belongs to the
@@ -221,6 +223,7 @@ void *pvReturn = NULL;
 					by the application and has no "next" block. */
 					pxBlock->xBlockSize |= xBlockAllocatedBit;
 					pxBlock->pxNextFreeBlock = NULL;
+					xNumberOfSuccessfulAllocations++;
 				}
 				else
 				{
@@ -292,6 +295,7 @@ BlockLink_t *pxLink;
 					xFreeBytesRemaining += pxLink->xBlockSize;
 					traceFREE( pv, pxLink->xBlockSize );
 					prvInsertBlockIntoFreeList( ( ( BlockLink_t * ) pxLink ) );
+					xNumberOfSuccessfulFrees++;
 				}
 				( void ) xTaskResumeAll();
 			}
@@ -432,5 +436,57 @@ uint8_t *puc;
 	{
 		mtCOVERAGE_TEST_MARKER();
 	}
+}
+/*-----------------------------------------------------------*/
+
+void vPortGetHeapStats( HeapStats_t *pxHeapStats )
+{
+BlockLink_t *pxBlock;
+size_t xBlocks = 0, xMaxSize = 0, xMinSize = portMAX_DELAY; /* portMAX_DELAY used as a portable way of getting the maximum value. */
+
+	vTaskSuspendAll();
+	{
+		pxBlock = xStart.pxNextFreeBlock;
+
+		/* pxBlock will be NULL if the heap has not been initialised.  The heap
+		is initialised automatically when the first allocation is made. */
+		if( pxBlock != NULL )
+		{
+			do
+			{
+				/* Increment the number of blocks and record the largest block seen
+				so far. */
+				xBlocks++;
+
+				if( pxBlock->xBlockSize > xMaxSize )
+				{
+					xMaxSize = pxBlock->xBlockSize;
+				}
+
+				if( pxBlock->xBlockSize < xMinSize )
+				{
+					xMinSize = pxBlock->xBlockSize;
+				}
+
+				/* Move to the next block in the chain until the last block is
+				reached. */
+				pxBlock = pxBlock->pxNextFreeBlock;
+			} while( pxBlock != pxEnd );
+		}
+	}
+	xTaskResumeAll();
+
+	pxHeapStats->xSizeOfLargestFreeBlockInBytes = xMaxSize;
+	pxHeapStats->xSizeOfSmallestFreeBlockInBytes = xMinSize;
+	pxHeapStats->xNumberOfFreeBlocks = xBlocks;
+
+	taskENTER_CRITICAL();
+	{
+		pxHeapStats->xAvailableHeapSpaceInBytes = xFreeBytesRemaining;
+		pxHeapStats->xNumberOfSuccessfulAllocations = xNumberOfSuccessfulAllocations;
+		pxHeapStats->xNumberOfSuccessfulFrees = xNumberOfSuccessfulFrees;
+		pxHeapStats->xMinimumEverFreeBytesRemaining = xMinimumEverFreeBytesRemaining;
+	}
+	taskEXIT_CRITICAL();
 }
 

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -116,10 +116,12 @@ static const size_t xHeapStructSize	= ( sizeof( BlockLink_t ) + ( ( size_t ) ( p
 /* Create a couple of list links to mark the start and end of the list. */
 static BlockLink_t xStart, *pxEnd = NULL;
 
-/* Keeps track of the number of free bytes remaining, but says nothing about
-fragmentation. */
+/* Keeps track of the number of calls to allocate and free memory as well as the
+number of free bytes remaining, but says nothing about fragmentation. */
 static size_t xFreeBytesRemaining = 0U;
 static size_t xMinimumEverFreeBytesRemaining = 0U;
+static size_t xNumberOfSuccessfulAllocations = 0;
+static size_t xNumberOfSuccessfulFrees = 0;
 
 /* Gets set to the top bit of an size_t type.  When this bit in the xBlockSize
 member of an BlockLink_t structure is set then the block belongs to the
@@ -231,6 +233,7 @@ void *pvReturn = NULL;
 					by the application and has no "next" block. */
 					pxBlock->xBlockSize |= xBlockAllocatedBit;
 					pxBlock->pxNextFreeBlock = NULL;
+					xNumberOfSuccessfulAllocations++;
 				}
 				else
 				{
@@ -301,6 +304,7 @@ BlockLink_t *pxLink;
 					xFreeBytesRemaining += pxLink->xBlockSize;
 					traceFREE( pv, pxLink->xBlockSize );
 					prvInsertBlockIntoFreeList( ( ( BlockLink_t * ) pxLink ) );
+					xNumberOfSuccessfulFrees++;
 				}
 				( void ) xTaskResumeAll();
 			}
@@ -481,5 +485,63 @@ const HeapRegion_t *pxHeapRegion;
 
 	/* Work out the position of the top bit in a size_t variable. */
 	xBlockAllocatedBit = ( ( size_t ) 1 ) << ( ( sizeof( size_t ) * heapBITS_PER_BYTE ) - 1 );
+}
+/*-----------------------------------------------------------*/
+
+void vPortGetHeapStats( HeapStats_t *pxHeapStats )
+{
+BlockLink_t *pxBlock;
+size_t xBlocks = 0, xMaxSize = 0, xMinSize = portMAX_DELAY; /* portMAX_DELAY used as a portable way of getting the maximum value. */
+
+	vTaskSuspendAll();
+	{
+		pxBlock = xStart.pxNextFreeBlock;
+
+		/* pxBlock will be NULL if the heap has not been initialised.  The heap
+		is initialised automatically when the first allocation is made. */
+		if( pxBlock != NULL )
+		{
+			do
+			{
+				/* Increment the number of blocks and record the largest block seen
+				so far. */
+				xBlocks++;
+
+				if( pxBlock->xBlockSize > xMaxSize )
+				{
+					xMaxSize = pxBlock->xBlockSize;
+				}
+
+				/* Heap five will have a zero sized block at the end of each
+				each region - the block is only used to link to the next
+				heap region so it not a real block. */
+				if( pxBlock->xBlockSize != 0 )
+				{
+					if( pxBlock->xBlockSize < xMinSize )
+					{
+						xMinSize = pxBlock->xBlockSize;
+					}
+				}
+
+				/* Move to the next block in the chain until the last block is
+				reached. */
+				pxBlock = pxBlock->pxNextFreeBlock;
+			} while( pxBlock != pxEnd );
+		}
+	}
+	xTaskResumeAll();
+
+	pxHeapStats->xSizeOfLargestFreeBlockInBytes = xMaxSize;
+	pxHeapStats->xSizeOfSmallestFreeBlockInBytes = xMinSize;
+	pxHeapStats->xNumberOfFreeBlocks = xBlocks;
+
+	taskENTER_CRITICAL();
+	{
+		pxHeapStats->xAvailableHeapSpaceInBytes = xFreeBytesRemaining;
+		pxHeapStats->xNumberOfSuccessfulAllocations = xNumberOfSuccessfulAllocations;
+		pxHeapStats->xNumberOfSuccessfulFrees = xNumberOfSuccessfulFrees;
+		pxHeapStats->xMinimumEverFreeBytesRemaining = xMinimumEverFreeBytesRemaining;
+	}
+	taskEXIT_CRITICAL();
 }
 

--- a/src/FreeRTOS/Source/History.txt
+++ b/src/FreeRTOS/Source/History.txt
@@ -1,0 +1,2752 @@
+Documentation and download available at http://www.FreeRTOS.org/
+
+Changes between FreeRTOS V10.3.0 and FreeRTOS V10.3.1 released February 18 2020
+
+	See http://www.FreeRTOS.org/FreeRTOS-V10.3.x.html
+
+	./FreeRTOS-Labs directory was removed from this file. The libraries it 
+	contained are now available as a separate download.
+
+Changes between FreeRTOS V10.2.1 and FreeRTOS V10.3.0 released February 7 2020
+
+	See http://www.FreeRTOS.org/FreeRTOS-V10.3.x.html
+
+	New and updated kernel ports:
+
+	+ Added RISC-V port for the IAR compiler.
+	+ Update the Windows simulator port to use a synchronous object to prevent
+	  a user reported error whereby a task continues to run for a short time
+	  after being moved to the Blocked state.  Note we were not able to
+	  replicate the reported issue and it likely depends on your CPU model.
+	+ Correct alignment of stack top in RISC-V port when
+	  configISR_STACK_SIZE_WORDS is defined to a non zero value, which causes
+	  the interrupt stack to be statically allocated.
+	+ The RISC-V machine timer compare register can now be for any HART, whereas
+	  previously it was always assumed FreeRTOS was running on HART 0.
+	+ Update the sequence used to update the 64-bit machine timer
+	  compare register on 32-bit cores to match that suggested in RISC-V
+	  documentation.
+	+ Added tickless low power modes into the ARM, IAR and GCC Cortex-M0 compiler
+	  ports.
+	+ Updated the behaviour of the ARMv7-M MPU (Memory Protection Unit) ports to
+	  match that of the ARMv8-M ports whereby privilege escalations can only
+	  originate from within the kernel's own memory segment.  Added
+	  configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY configuration constant.
+	+ Update existing MPU ports to correctly disable the MPU before it is
+	  updated.
+	+ Added contributed port and demo application for a T-Head (formally C-SKY)
+	  microcontroller.
+
+	New API functions:
+
+	+ Added the vPortGetHeapStats() API function which returns information on
+	  the heap_4 and heap_5 state.
+	+ Added xTaskCatchUpTicks(), which corrects the tick count value after the
+	  application code has held interrupts disabled for an extended period.
+	+ Added xTaskNotifyValueClear() API function.
+	+ Added uxTimerGetReloadMode() API function.
+
+	Other miscellaneous changes:
+	+ Change type of uxPendedTicks from UBaseType_t to TickType_t to ensure it
+	  has the same type as variables with which it is compared to, and therefore
+	  also renamed the variable xPendingTicks.
+	+ Update Keil projects that use the MPU so memory regions come from linker
+	  script (scatter file) variables instead of being hard coded.
+	+ Added LPC51U68 Cortex-M0+ demos for GCC (MCUXpresso), Keil and IAR
+	  compilers.
+	+ Added CORTEX_MPU_STM32L4_Discovery_Keil_STM32Cube demo.
+	+ Added LPC54018 MPU demo.
+	+ Rename xTaskGetIdleRunTimeCounter() to ulTaskGetIdleRunTimeCounter().
+
+
+Changes between FreeRTOS V10.2.1 and FreeRTOS V10.2.0 released May 13 2019:
+
+	+ Added ARM Cortex-M23 port layer to complement the pre-existing ARM
+	  Cortex-M33 port layer.
+	+ The RISC-V port now automatically switches between 32-bit and 64-bit
+	  cores.
+	+ Introduced the portMEMORY_BARRIER macro to prevent instruction re-ordering
+	  when GCC link time optimisation is used.
+	+ Introduced the portDONT_DISCARD macro to the ARMv8-M ports to try and
+	  prevent the secure side builds from removing symbols required by the
+	  non secure side build.
+	+ Introduced the portARCH_NAME to provide additional data to select semi-
+	  automated build environments.
+	+ Cortex-M33 and Cortex-M23 ports now correctly disable the MPU before
+	  updating the MPU registers.
+
+	+ Added Nuvoton NuMaker-PFM-M2351 ARM Cortex-M23 demo.
+	+ Added LPC55S69 ARM Cortex-M33 demo.
+	+ Added an STM32 dual core AMP stress test demo.
+
+
+Changes between FreeRTOS V10.1.1 and FreeRTOS V10.2.0 released February 25 2019:
+
+	+ Added GCC RISC-V MCU port with three separate demo applications.
+	+ Included pre-existing ARM Cortex-M33 (ARMv8-M) GCC/ARMclang and IAR ports
+	  with Keil simulator demo.
+	+ Update the method used to detect if a timer is active.  Previously the
+	  timer was deemed to be inactive if it was not referenced from a list.
+	  However, when a timer is updated it is temporarily removed from, then
+	  re-added to a list, so now the timer's active status is stored separately.
+	+ Add vTimerSetReloadMode(), xTaskGetIdleRunTimeCounter(), and
+	  xTaskGetApplicationTaskTagFromISR() API functions.
+	+ Updated third party Xtensa port so it is MIT licensed.
+	+ Added configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H to the Renesas
+	  compiler RX600v2 port to enable switching between platform.h and
+	  iodefine.h includes within that port's port.c file.
+	+ Removed the 'FromISR' functions from the MPU ports as ISRs run privileged
+	  anyway.
+	+ Added uxTaskGetStackHighWaterMark2() function to enable the return type to
+	  be changed without breaking backward compatibility.
+	  uxTaskGetStackHighWaterMark() returns a UBaseType_t as always,
+	  uxTaskGetStackHighWaterMark2() returns configSTACK_DEPTH_TYPE to allow the
+	  user to determine the return type.
+	+ Fixed issues in memory protected ports related to different combinations
+	  of static memory only and dynamic memory only builds.  As a result the
+	  definition of tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE became more
+	  complex and was moved to FreeRTOS.h with a table explaining its definition.
+	+ Added a 'get task tag from ISR' function.
+	+ Change the method used to determine if a timer is active or not from just
+	  seeing if it is referenced from the active timer list to storing its
+	  active state explicitly.  The change prevents the timer reporting that it
+	  is inactive while it is being moved from one list to another.
+	+ The pcName parameter passed into the task create functions can be NULL,
+	  previously a name had to be provided.
+	+ When using tickless idle, prvResetNextTaskUnblockTime() is now only called
+	  in xTaskRemoveFromEventList() if the scheduler is not suspended.
+	+ Introduced portHAS_STACK_OVERFLOW_CHECKING, which should be set to 1 for
+	  FreeRTOS ports that run on architectures that have stack limit registers.
+
+
+Changes between FreeRTOS V10.1.0 and FreeRTOS V10.1.1 released 7 September 2018
+
+	+ Reverted a few structure name changes that broke several kernel aware
+	  debugger plug-ins.
+	+ Updated to the latest trace recorder code.
+	+ Fixed some formatting in the FreeRTOS+TCP TCP/IP stack code.
+	+ Reverted moving some variables from file to function scope as doing so
+	  broke debug scenarios that require the static qualifier to be removed.
+
+Changes between FreeRTOS V10.0.1 and FreeRTOS V10.1.0 released 22 August 2018
+
+	FreeRTOS Kernel Changes:
+
+	+ Update lint checked MISRA compliance to use the latest MISRA standard, was
+	  previously using the original MISRA standard.
+	+ Updated all object handles (TaskHandle_t, QueueHandle_t, etc.) to be
+	  unique types instead of void pointers, improving type safety.  (this was
+	  attempted some years back but had to be backed out due to bugs in some
+	  debuggers).  Note this required the pvContainer member of a ListItem_t
+	  struct to be renamed - set configENABLE_BACKWARD_COMPATIBILITY to 1 if
+	  this causes an issue.
+	+ Added configUSE_POSIX_ERRNO to enable per task POSIX style errno
+	  functionality in a more user friendly way - previously the generic thread
+	  local storage feature was used for this purpose.
+	+ Added Xtensa port and demo application for the XCC compiler.
+	+ Changed the implementation of vPortEndScheduler() for the Win32 port to
+	  simply call exit( 0 ).
+	+ Bug fix in vPortEnableInterrupt() for the GCC Microblaze port to protect
+	  the read modify write access to an internal Microblaze register.
+	+ Fix minor niggles when the MPU is used with regards to prototype
+	  differences, static struct size differences, etc.
+	+ The usStackHighWaterMark member of the TaskStatus_t structure now has type
+	  configSTACK_DEPTH_TYPE in place of uint16_t - that change should have been
+	  made when the configSTACK_DEPTH_TYPE type (which gets around the previous
+	  16-bit limit on stack size specifications) was introduced.
+	+ Added the xMessageBufferNextLengthBytes() API function and likewise stream
+	  buffer equivalent.
+	+ Introduce configMESSAGE_BUFFER_LENGTH_TYPE to allow the number of bytes
+	  used to hold the length of a message in the message buffer to be reduced.
+	  configMESSAGE_BUFFER_LENGTH_TYPE default to size_t, but if, for example,
+	  messages can never be more than 255 bytes it could be set to uint8_t,
+	  saving 3 bytes each time a message is written into the message buffer
+	  (assuming sizeof( size_t ) is 4).
+	+ Updated the StaticTimer_t structure to ensure it matches the size of the
+	  Timer_t structure when the size of TaskFunction_t does not equal the size
+	  of void *.
+	+ Update various Xilinx demos to use 2018.1 version of the SDK tools.
+	+ Various updates to demo tasks to maintain test coverage.
+	+ FreeRTOS+UDP was removed in FreeRTOS V10.1.0 as it was replaced by
+	  FreeRTOS+TCP, which was brought into the main download in FreeRTOS
+	  V10.0.0.  FreeRTOS+TCP can be configured as a UDP only stack, and
+	  FreeRTOS+UDP does not contain the patches applied to FreeRTOS+TCP.
+
+	FreeRTOS+TCP Changes:
+
+	+ Multiple security improvements and fixes in packet parsing routines, DNS
+	  caching, and TCP sequence number and ID generation.
+	+ Disable NBNS and LLMNR by default.
+	+ Add TCP hang protection by default.
+
+	We thank Ori Karliner of Zimperium zLabs Team for reporting these issues.
+
+
+Changes between FreeRTOS V10.0.0 and FreeRTOS V10.0.1, released December 20 2017
+
+	+ Fix position of "#if defined( __cplusplus )" in stream_buffer.h.
+	+ Correct declarations of MPU_xQueuePeek() and MPU_xQueueSemaphoreTake() in
+	  mpu_prototypes.h.
+	+ Correct formatting in vTaskList() helper function when it prints the state
+	  of the currently executing task.
+	+ Introduce #error if stream_buffer.c is built without
+	  configUSE_TASK_NOTIFICATIONS set to 1.
+	+ Update FreeRTOS+TCP to V2.0.0
+		- Improve the formatting of text that displays the available netword
+		  interfaces when FreeRTOS+TCP is used on Windows with WinPCap.
+		- Introduce ipconfigSOCKET_HAS_USER_WAKE_CALLBACK option to enable a user
+		  definable callback to execute when data arrives on a socket.
+
+Changes between FreeRTOS V9.0.1 and FreeRTOS V10.0.0:
+
+	The FreeRTOS kernel is now MIT licensed: https://www.FreeRTOS.org/license
+
+	New Features and components:
+
+	+ Stream Buffers - see http://www.FreeRTOS.org/RTOS-stream-buffer-example.html
+	+ Message Buffers - see http://www.FreeRTOS.org//RTOS-message-buffer-example.html
+	+ Move FreeRTOS+TCP into the main repository, along with the basic Win32
+	  TCP demo FreeRTOS_Plus_TCP_Minimal_Windows_Simulator.
+
+	New ports or demos:
+
+	+ Added demo for TI SimpleLink CC3220 MCU.
+	+ Added MPU and non MPU projects for Microchip CEC and MEC 17xx and 51xx
+	  MCUs.
+	+ Added CORTEX_MPU_Static_Simulator_Keil_GCC demo to test static allocation
+	  in the MPU port.
+
+	Fixes or enhancements:
+
+	+ Cortex-M ports push additional register prior to calling
+	  vTaskSwitchContext to ensure 8-byte alignment is maintained.  Only
+	  important if a user defined tick hook function performs an operation that
+	  requires 8-byte alignment.
+	+ Optimisations to the implementation of the standard tickless idle mode on
+	  Cortex-M devices.
+	+ Improvements to the Win32 port including using higher priority threads.
+	+ Ensure interrupt stack alignment on PIC32 ports.
+	+ Updated GCC TriCore port to build with later compiler versions.
+	+ Update mpu_wrappers.c to support static allocation.
+	+ The uxNumberOfItems member of List_t is now volatile - solving an issue
+	  when the IAR compiler was used with maximum optimization.
+	+ Introduced configRECORD_STACK_HIGH_ADDRESS.  When set to 1 the stack start
+	  address is saved into each task's TCB (assuming stack grows down).
+	+ Introduced configINCLUDE_FREERTOS_TASK_C_ADDITIONS_H to allow user defined
+	  functionality, and user defined initialisation, to be added to FreeRTOS's
+	  tasks.c source file.  When configINCLUDE_FREERTOS_TASK_C_ADDITIONS_H is
+	  set to 1 a user provided header file called freertos_task_c_additions.h
+	  will be included at the bottom of tasks.c.  Functions defined in that
+	  header file can call freertos_tasks_c_additions_init(), which in turn
+	  calls a macro called FREERTOS_TASKS_C_ADDITIONS_INIT(), if it is defined.
+	  FREERTOS_TASKS_C_ADDITIONS_INIT() can be defined in FreeRTOSConfig.h.
+	+ Introduced configPRE_SUPPRESS_TICKS_AND_SLEEP_PROCESSING( x ) which can be
+	  defined by a user in FreeRTOSConfig.h.  The macro is called before
+	  assessing whether to enter tickless idle mode or not.  If the macro sets
+	  x to zero then tickless idle mode will not be entered.  This allows users
+	  to abort tickless idle mode entry before the tickless idle function is
+	  even called - previously it was only possible to abort from within the
+	  tickless idle function itself.
+	+ Added configPRINTF(), which can be defined by users to allow all libraries
+	  to use the same print formatter.
+	+ Introduced configMAX() and configMIN() macros which default to standard
+	  max( x, y ) and min( x, y ) macro behaviour, but can be overridden if the
+	  application writer defines the same macros in FreeRTOSConfig.h.
+	+ Corrected the definition of StaticTask_t in the case where
+	  INCLUDE_xTaskAbortDelay is set to 1.
+	+ Introduced configTIMER_SERVICE_TASK_NAME and configIDLE_TASK_NAME, both of
+	  which can be defined to strings in FreeRTOSConfig.h to change the default
+	  names of the timer service and idle tasks respectively.
+	+ Only fill the stack of a newly created task with a known value if stack
+	  checking, or high water mark checking/viewing, is in use - removing the
+	  dependency on memset() in other cases.
+	+ Introduced xTaskCreateRestrictedStatic() so static allocation can be used
+	  with the MPU.
+	+ Ensure suspended tasks cannot be unsuspended by a received task
+	  notification.
+	+ Fix race condition in vTaskSetTimeOutState().
+	+ Updated trace recorder files to the latest version.
+
+Changes since FreeRTOS V9.0.0:
+
+	+ Priority dis-inheritance behaviour has been enhanced in the case where a
+	  task that attempted to take a mutex that was held by a lower priority task
+	  timed out before it was able to obtain the mutex (causing the task that
+	  holds the mutex to have its priority raised, then lowered again, in
+	  accordance with the priority inheritance protocol).
+	+ Split the overloaded xQueueGenericReceive() function into three separate
+	  dedicated functions.
+	+ Allow the default human readable text names given to the Idle and Timer
+	  tasks to be overridden by defining the configIDLE_TASK_NAME and
+	  configTIMER_SERVICE_TASK_NAME definitions respectively in FreeRTOSConfig.h.
+	+ Introduced configINITIAL_TICK_COUNT to allow the tick count to take a
+	  value of than than 0 when the system boots.  This can be useful for
+	  testing purposes - although setting configUSE_16_BIT_TICKS to 1 can also
+	  be used to test frequent tick overflows.
+	+ Ensure the Cortex-M SysTick count is cleared to zero before starting the
+	  first task.
+	+ Add configASSERT() into ARM Cortex-M ports to check the number of priority
+	  bit settings.
+	+ Clear the 'control' register before starting ARM Cortex-M4F ports in case
+	  the FPU is used before the scheduler is started.  This just saves a few
+	  bytes on the main stack as it prevents space being left for a later save
+	  of FPU registers.
+	+ Added xSemaphoreGetMutexHolderFromISR().
+	+ Corrected use of portNVIC_PENDSVSET to portNVIC_PENDSVSET_BIT in MPU ports.
+	+ Introduced configSTACK_DEPTH_TYPE to allow users to change the type used
+	  to specify the stack size when using xTaskCreate().  For historic reasons,
+	  when FreeRTOS was only used on small MCUs, the type was set to uint16_t,
+	  but that can be too restrictive when FreeRTOS is used on larger
+	  processors.  configSTACK_DEPTH_TYPE defaults to uint16_t.
+	  xTaskCreateStatic(), being a newer function, used a uint32_t.
+	+ Increase the priority of the Windows threads used by the Win32 port.  As
+	  all the threads run on the same core, and the threads run with very high
+	  priority, there is a risk that the host will become unresponsive, so also
+	  prevent the Windows port executing on single core hosts.
+
+Changes between FreeRTOS V9.0.0 and FreeRTOS V9.0.0rc2 released May 25 2016:
+
+	See http://www.FreeRTOS.org/FreeRTOS-V9.html
+
+	RTOS kernel updates:
+
+	+ The prototype of the new xTaskCreateStatic() API function was modified to
+	  remove a parameter and improve compatibility with other new
+	  "CreateStatic()" API functions.  The stack size parameter in
+	  xTaskCreateStatic() is now uint32_t, which changes the prototype of the
+	  callback functions.  See the following URL:
+	  http://www.freertos.org/xTaskCreateStatic.html
+	+ GCC ARM Cortex-A port:  Introduced the configUSE_TASK_FPU_SUPPORT
+	  constant.  When configUSE_TASK_FPU_SUPPORT is set to 2 every task is
+	  automatically given a floating point (FPU) context.
+	+ GCC ARM Cortex-A port:  It is now possible to automatically save and
+	  restore all floating point (FPU) registers on entry to each potentially
+	  nested interrupt by defining vApplicationFPUSafeIRQHandler() instead of
+	  vApplicationIRQHandler().
+	+ All ARM Cortex-M3/4F/7 ports:  Clear the least significant bit of the task
+	  entry address placed onto the stack of a task when the task is created for
+	  strict compliance with the ARM Cortex-M3/4/7 architecture documentation
+	  (no noticeable effect unless using the QMEU emulator).
+	+ Added GCC and Keil ARM Cortex-M4F MPU ports - previously the MPU was only
+	  supported on ARM Cortex-M3.
+	+ ARM Cortex-M3/4F MPU ports:  Update to fully support the FreeRTOS V9.0.0
+	  API (other than static object creation) and added the
+	  FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC demo application to
+	  demonstrate how to use the updated MPU port.
+	+ All ARM Cortex-M3/4F/7 ports:  Add additional barrier instructions to the
+	  default low power tickless implementation.
+	+ All ARM Cortex-M0 ports:  Prevent an item being left on the stack of the
+	  first task that executes.
+	+ Win32 ports:  Reduce the amount of stack used and change the way Windows
+	  threads are deleted to increase the maximum execution time.
+	+ Add an ARM Cortex-M4F port for the MikroC compiler.  Ensure to read the
+	  documentation page for this port before use.
+	+ MPS430X IAR port:  Update to be compatible with the latest EW430 tools
+	  release.
+	+ IAR32 GCC port:  Correct vPortExitCritical() when
+	  configMAX_API_CALL_INTERRUPT_PRIORITY == portMAX_PRIORITY.
+	+ For consistency vTaskGetTaskInfo() now has the alias vTaskGetInfo(),
+	  xTaskGetTaskHandle() now has the alias xTaskGetHandle() and
+	  pcQueueGetQueueName() now has an alias pcQueueGetName().
+	+ Fix various errors in comments and compiler warnings.
+
+	Demo application updates:
+
+	+ Update Atmel Studio projects to use Atmel Studio 7.
+	+ Update Xilinx SDK projects to use the 2016.1 version of the SDK.
+	+ Remove dependency on legacy IO libraries from the PIC32 demos.
+	+ Move the Xilinx UltraScale Cortex-R5 demo into the main distribution.
+	+ Update the MSP432 libraries to the latest version.
+	+ Add Microchip CEC1302 (ARM Cortex-M4F) demos for GCC, Keil and MikroC
+	  compilers.
+	+ Move the Atmel SAMA5D2 demo into the main distribution.
+
+Changes between FreeRTOS V9.0.0rc1 and FreeRTOS V9.0.0rc2 (release candidate 2)
+released March 30 2016:
+
+	NOTE - See http://www.FreeRTOS.org/FreeRTOS-V9.html for details
+
+	+ The functions that create RTOS objects using static memory allocation have
+	  been simplified and will not revert to using dynamic allocation if a
+	  buffer is passed into a function as NULL.
+	+ Introduced the configSUPPORT_DYNAMIC_ALLOCATION configuration constant to
+	  allow a FreeRTOS application to be built without a heap even being being
+	  defined. The Win32 example located in the
+	  /FreeRTOS/demo/WIN32-MSVC-Static-Allocation-Only directory is provided as
+	  a reference for projects that do not include a FreeRTOS heap.
+	+ Minor run-time optimisations.
+	+ Two new low power tickless implementations that target Silicon Labs EFM32
+	  microcontrollers.
+	+ Addition of the xTimerGetPeriod() and xTimerGetExpireTime() API functions.
+
+Changes between FreeRTOS V8.2.3 and FreeRTOS V9.0.0rc1 (release candidate 1)
+released February 19 2016:
+
+	RTOS Kernel Updates:
+
+	+ Major new feature - tasks, semaphores, queues, timers and event groups can
+	  now be created using statically allocated memory, so without any calls to
+	  pvPortMalloc().
+	+ Major new features - Added the xTaskAbortDelay() API function which allows
+	  one task to force another task to immediately leave the Blocked state,
+	  even if the event the blocked task is waiting for has not occurred, or the
+	  blocked task's timeout has not expired.
+	+ Updates necessary to allow FreeRTOS to run on 64-bit architectures.
+	+ Added vApplicationDaemonTaskStartupHook() which executes when the RTOS
+	  daemon task (which used to be called the timer service task) starts
+	  running.  This is useful if the application includes initialisation code
+	  that would benefit from executing after the scheduler has been started.
+	+ Added the xTaskGetTaskHandle() API function, which obtains a task handle
+	  from the task's name.  xTaskGetTaskHandle() uses multiple string compare
+	  operations, so it is recommended that it is called only once per task.
+	  The handle returned by xTaskGetTaskHandle() can then be stored locally for
+	  later re-use.
+	+ Added the pcQueueGetQueueName() API function, which obtains the name of
+	  a queue from the queue's handle.
+	+ Tickless idling (for low power applications) can now also be used when
+	  configUSE_PREEMPTION is 0.
+	+ If one task deletes another task, then the stack and TCB of the deleted
+	  task is now freed immediately.  If a task deletes itself, then the stack
+	  and TCB of the deleted task are freed by the Idle task as before.
+	+ If a task notification is used to unblock a task from an ISR, but the
+	  xHigherPriorityTaskWoken parameter is not used, then pend a context switch
+	  that will then occur during the next tick interrupt.
+	+ Heap_1.c and Heap_2.c now use the configAPPLICATION_ALLOCATED_HEAP
+	  settings, which previously was only used by heap_4.c.
+	  configAPPLICATION_ALLOCATED_HEAP allows the application writer to declare
+	  the array that will be used as the FreeRTOS heap, and in-so-doing, place
+	  the heap at a specific memory location.
+	+ TaskStatus_t structures are used to obtain details of a task.
+	  TaskStatus_t now includes the bae address of the task's stack.
+	+ Added the vTaskGetTaskInfo() API function, which returns a TaskStatus_t
+	  structure that contains information about a single task.  Previously this
+	  information could only be obtained for all the tasks at once, as an array
+	  of TaskStatus_t structures.
+	+ Added the uxSemaphoreGetCount() API function.
+	+ Replicate previous Cortex-M4F and Cortex-M7 optimisations in some
+	  Cortex-M3 port layers.
+
+	Demo Application Updates:
+
+	Further demo applications will be added prior to the final FreeRTOS V9
+	release.
+
+	+ Updated SAM4L Atmel Studio project to use Atmel Studio 7.
+	+ Added ARM Cortex-A53 64-bit port.
+	+ Added a port and demo for the ARM Cortex-A53 64-bit cores on the Xilinx
+	  Ultrascale MPSoC.
+	+ Added Cortex-M7 SAME70 GCC demo.
+	+ Added EFM32 Giant and Wonder Gecko demos.
+
+
+Changes between V8.2.2 and V8.2.3 released October 16, 2015
+
+	RTOS kernel updates:
+
+	+ Fix bug identified in a modification made in V8.2.2 to the software timer
+	  code that allows tickless low power applications to sleep indefinitely
+	  when software timers are used.
+	+ Simplify and improve efficiency of stack overflow checking.
+	+ Add xTaskNotifyStateClear() API function.
+	+ New IAR and GCC Cortex-R ports for microprocessors that do not use an ARM
+	  generic interrupt controller (GIC).
+	+ New PIC32MEC14xx port.
+	+ Add support for PIC32MZ EF parts (with floating point) into the PIC32MZ
+	  port.
+	+ Zynq7000 port layer now declares the functions that setup and clear the
+	  tick interrupt as weak symbols so they can be overridden by the
+	  application, and uses a global XScuGic object so the same object can be
+	  used by the application code.
+	+ Introduced configUSE_TASK_FPU_SUPPORT, although the PIC32MZ EF port is
+	  currently the only port that uses it.
+	+ Updates to RL78 and 78K0 IAR port layers to improve support for
+	  combinations of memory models.
+	+ Minor updates to heap_5.c to remove compiler warnings generated by some
+	  compilers.
+	+ License simplifications.  See /FreeRTOS/License/license.txt in the
+	  official distribution.
+
+	FreeRTOS+ updates:
+
+	+ Update directory names to use WolfSSL instead of CyaSSL, inline with
+	  WolfSSL's re-branding.
+	+ Update to latest WolfSSL code.
+	+ Update to latest FreeRTOS+Trace recorder code.
+	+ Add in the FreeRTOS+Trace recorder library required for streaming trace.
+
+	Demo application changes:
+
+	+ Add demo applications for Renesas RZ/T (Cortex-R), PIC32MZ EF (PIC32 with
+	  floating point hardware), PIC32MEC14xx, RX71M, RX113 and RX231.
+	+ General tidy up of spelling and compiler warnings.
+
+
+Changes between V8.2.1 and V8.2.2 released August 12, 2015
+
+	RTOS kernel updates:
+
+	+ Added Intel IA32/x86 32-bit port.
+	+ General maintenance.
+	+ PRIVILEGED_FUNCTION and PRIVILEGED_DATA macros, which are used in memory
+	  protected systems, have been added to the newer event group and software
+	  timer functions.
+	+ Add the errno definitions used by FreeRTOS+ components into projdefs.h.
+	+ Remove the restriction that prevented tick-less idle implementations
+	  waiting indefinitely when software timers were used in the same
+	  application.
+	+ Introduce xTaskNotifyAndQueryFromISR() as the interrupt safe version of
+	  xTaskNotifyAndQuery().
+	+ Add additional NOPs to the MSP430X port layers to ensure strict compliance
+	  with the hardware documentation.
+	+ Microblaze port: Added option for port optimised task selection.
+	+ Microblaze port: Previously tasks inherited the exception enable state
+	  at the time the task was created.  Now all tasks are created with
+	  exceptions enabled if the Microblaze design supports exceptions.
+	+ Windows port: Add additional safe guards to ensure the correct start up
+	  sequence and thread switching timing.
+	+ Windows port: Improve the implementation of the port optimised task
+	  selection assembly code.
+	+ Update heap_4 and heap_5 to allow use on 64-bit processors.
+	+ Simplify the code that creates a queue.
+	+ General improved tick-less idle behaviour.
+	+ Ensure none of the variables in the common kernel files are initialised to
+	  anything other than zero.
+	+ Correct calculation of xHeapStructSize in heap_4 and heap_5.
+
+	Demo application updates:
+
+	+ Added demo project for the new IA32/x86 port that targets the Galileo
+	  hardware.
+	+ Added MSP430FR5969 demos (previously provided as a separate download).
+	+ Added FreeRTOS BSP repository for automatic creation of FreeRTOS
+	  applications in the Xilinx SDK.
+	+ Added Atmel Studio / GCC project for the SAMV71 (ARM Cortex-M7)
+	+ Update Xilinx SDK projects to use version 2015.2 of the SDK.
+	+ Remove Microblaze demos that were using obsolete tools.
+	+ Add MSP43FR5969 IAR and CCS demos.
+
+	FreeRTOS+ Updates:
+
+	+ Updated FreeRTOS+Trace recorder library, which requires an update to the
+	  FreeRTOS+Trace application.
+	+ Added Reliance Edge source code and demo application.  Reliance edge is
+	  a fail safe transactional file system ideal for applications that require
+	  file storage, and especially when high reliability is essential.
+	+ Introduce configAPPLICATION_PROVIDES_cOutputBuffer to allow FreeRTOS+CLI
+	  users to place the output buffer at a fixed memory address.
+	+ Improve the NetworkInterface.c file provided for the Windows port of
+	  FreeRTOS+UDP.
+
+Changes between V8.2.0 and V8.2.1 released 24th March 2015.
+
+	RTOS kernel updates:
+
+	+ Added user definable and flexible thread local storage facility.
+	+ Added vTimerSetTimerID() API function to complement the pvTimerGetTimerID()
+	  function to allow the timer's ID to be used as timer local storage.
+	+ Fixed a potential issue related to the use of queue sets from an ISR.
+	+ Some updates to the Xilinx Microblaze GCC port.
+	+ Added ARM Cortex-M4F port for Texas Instruments Code Composer Studio.
+	+ Added ARM Cortex-M7 r0p1 port layer for IAR, GCC and Keil which contains a
+	  minor errata work around.  All other ARM Cortex-M7 core revisions should
+	  use the ARM Cortex-M4F port.
+	+ Exclude the whole of croutine.c if configUSE_CO_ROUTINES is set to 0.
+	+ Change some data types from uint32_t to size_t in preparation for 64-bit
+	  Windows port.
+	+ Update the PIC32 port to remove deprecation warnings output by the latest
+	  XC32 compilers.
+	+ Fix bug when xQueueOverwrite() and xQueueOverwrite() from ISR are used to
+	  overwrite items in two queues that are part of the same set.
+
+	Demo application updates:
+
+	+ Added demo application for TI's ARM Cortex-M4F based MSP432
+	  microcontroller using IAR, Keil and CCS compilers.
+	+ Added demo application for STM32F ARM Cortex-M7 based microcontroller
+	  using IAR and Keil.
+	+ Added demo application for Atmel SAMV71 ARM Cortex-M7 based
+	  microcontroller using IAR and Keil.
+	+ Added Microblaze demo that uses the 2014.4 version of the Xilinx SDK and
+	  runs on the KC705 evaluation board (Kintex FPGA).
+
+Changes between V8.1.2 and V8.2.0 released 16th January 2015
+
+	Changes between release candidate 1 and the official release are restricted
+	to maintenance only.
+
+	Significant RTOS kernel updates:
+
+	+ MAJOR NEW FEATURE!  Task notifications.  Please see the following URL for
+	  details: http://www.FreeRTOS.org/RTOS-task-notifications.html
+	+ NEW HEADER FILE REQUIRED!  Obsolete definitions have been separated into
+	  a new header file called FreeRTOS/Source/include/deprecated_definitions.h.
+	  This header file must be present to build.  Note some of the obsolete
+	  definitions are still used by very old demo application projects.
+
+	Other RTOS kernel updates:
+
+	+ Made xSemaphoreGiveFromISR() a function rather than a macro that calls
+	  xQueueGenericSendFromISR().  This allows for major performance
+	  enhancements at the expense of some additional code size if both functions
+	  are used in the same application.  NOTE:  In most uses cases such use of
+	  a semaphore can now be replaced with a task notification which is smaller
+	  and faster still.
+	+ The TCB is now always allocated such that the task's stack grows away from
+	  the TCB (improves debugging of stack overflows as the overflow will not
+	  overwrite the task's name).
+	+ GCC, IAR and Keil Cortex-M4F ports now use more inlining (performance
+	  enhancements at the cost of a little additional code space).
+	+ Queues are now allocated with a single call to pvPortMalloc() which
+	  allocates both the queue structure and the queue storage area.
+	+ Introduced a new critical section macro for reading the tick count that
+	  defines away to nothing in cases where the width of the tick allows the
+	  tick count to be read atomically (performance benefits - especially when
+	  optimisation is on).
+	+ Introduced configAPPLICATION_ALLOCATED_HEAP in heap_4.c to allow the
+	  application writer to provide their own heap array - and in so doing
+	  control the location of the heap.
+	+ Introduced configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES which, when set, will
+	  include known values in both list and list item structures.  The values
+	  are intended to assist debugging.  If the values get overwritten then it
+	  is likely application code has written over RAM used by the kernel.
+	+ configASSERT()s in all Cortex-M ports used to test the lowest 5 bits of
+	  the interrupt control register to detect taskENTER_CRITICAL() being called
+	  from an interrupt.  This has been changed to test all 8 bits.
+	+ Introduced uxTaskPriorityGetFromISR().
+	+ Microblze V8 port now tests XPAR_MICROBLAZE_0_USE_FPU for inequality to 0
+	  rather than equality to 1, and 2 and 3 are also valid values.
+	+ Cortex-A5 GIC-less port no longer passes the address of the interrupting
+	  peripheral into the interrupt handler.
+	+ Fix an issue in FreeRTOS-MPU where an attempt was made to free the stack
+	  belonging to a task when the task was deleted, even when the stack was
+	  allocated statically.
+	+ Utility (helper) functions that format task statistic information into
+	  human readable tables now pad task names with spaces to ensure columns
+	  line up correctly even where task name lengths vary greatly.
+	+ Update FreeRTOS+Trace recorder library to version 2.7.0.
+
+	Demo application updates:
+
+	+ Added two new standard demo task sets:  IntSemTest and TaskNotify.
+	+ Added port and demo application for Atmel SAMA5D4 Cortex-A5 MPU.
+	+ Added demo application for Altera Cyclone V Cortex-A9 MPU.
+	+ Updated Zynq demo to use version 2014.4 of Xilinx's SDK and added in
+	  demo tasks for new RTOS features.
+	+ Updated Atmel SAM4E and SAM4S demos to include a lot of additional test
+	  and demo tasks.
+	+ Fixed a corner case issue in Atmel SAM4L low power tickless
+	  implementation, and added button interrupt handling.
+	+ Make the interrupt queue tests more tolerant to heave CPU loads.
+	+ Updated MSVC FreeRTOS simulator demo to include the latest standard test
+	  and demo tasks.
+	+ Updated MingW/Eclipse FreeRTOS simulator demo to match the FreeRTOS MSVC
+	  simulator demo.
+	+ Updated all demos that use FreeRTOS+Trace to work with the latest trace
+	  recorder code.
+
+
+Changes between V8.1.1 and V8.1.2 released September 2nd 2014
+
+	Move the defaulting of configUSE_PORT_OPTIMISED_TASK_SELECTION into the
+	individual port layers where necessary so it does not affect ports that do
+	not support the definition.
+
+Changes between V8.1.0 and V8.1.1 released August 29th 2014
+
+	By popular requests - a minor patch to V8.1.0 to re-instate the ability to
+	give a mutex type semaphore (with priority inheritance) from an interrupt
+	handler.
+
+Changes between V8.0.1 and V8.1.0 released August 26th 2014
+
+	FreeRTOS scheduler, kernel, demo and test updates:
+
+	+ Improved the priority inheritance algorithms to assist integration with
+	  off the shelf middleware that may hold multiple mutexes simultaneously.
+	+ Introduce heap_5.c, which is similar to heap_4.c but allows the heap to
+	  span multiple non-contiguous memory regions.
+	+ Updated all Cortex-A9 ports to help trap a couple of common usage errors -
+	  the first being when a task incorrectly attempts to exit its implementing
+	  function and the second being when a non interrupt safe API function is
+	  called from an interrupt.
+	+ Update all Cortex-A9 ports to remove obsolete mode switches prior to
+	  restoring a task context.
+	+ configUSE_PORT_OPTIMISED_TASK_SELECTION now defaults to 1 instead of 0.
+	+ Update all Cortex-M3/4F ports to trap a non interrupt safe API function
+	  being called from an interrupt handler.
+	+ Simplify the alignment checks in heap_4.c.
+	+ Update the MSVC Windows simulator demo to use heap_5.c in place of
+	  heap_4.c to ensure end users have an example to refer to.
+	+ Updated standard demo test code to test the new priority inheritance
+	  algorithms.
+	+ Updated the standard demo tasks to make use of stdint and the FreeRTOS
+	  specific typedefs that were introduced in FreeRTOS V8.0.0.
+	+ Introduce the pdMS_TO_TICKS() macro as a more user friendly and intuitive
+	  alternative to pdTICKS_PER_MS - both of which can be used to convert a
+	  time specified in milliseconds to a time specified in RTOS ticks.
+	+ Fix a bug in the Tasking compiler's Cortex-M port that resulted in an
+	  incorrect value being written to the basepri register.  This only effects
+	  users of the Tasking compiler.
+	+ Update the Zynq demo to use version 2014.2 of the SDK and add in an lwIP
+	  example that demonstrates lwIP being used with both its raw and sockets
+	  interfaces.
+	+ Updated the CCS Cortex-R4 port to enable it to be built with the latest
+	  CCS compiler.
+
+	New ports and demo applications:
+
+	+ Two Renesas RX64M ports (RXv2 core) and demos introduced, one for the GCC
+	  compiler and one for the Renesas compiler.  Both demos use e2 studio.
+	+ Generic IAR Cortex-A5 port (without any reliance on a GIC) introduced.
+	  The new port is demonstrated on an Atmel SAMA5D3 XPlained board.
+
+	FreeRTOS+ component updates:
+
+	+ Update CyaSSL to the latest version.
+	+ Updated the FreeRTOS+ components supplied directly by Real Time Engineers
+	  Ltd. to make use of stdint and the FreeRTOS specific typedefs that were
+	  introduced in FreeRTOS V8.0.0.
+	+ Rework and simplify the FreeRTOS+FAT SL RAM disk driver.
+
+	Miscellaneous updates and maintenance:
+
+	+ Update the IAR and DS-5/ARM RZ demos to target the official RZ RSK
+	  hardware in place of the previously targeted Renesas internal (not
+	  publicly available) hardware.
+	+ Various other maintenance tasks.
+
+
+Changes between V8.0.0 and V8.0.1 released 2nd May 2014
+
+	+ Minor fixes to the event group functionality that was released in V8.0.0.
+	  The 'clear bits from ISR' functionality is now implemented using a
+	  deferred interrupt callback instead of a function, and the 'wait bits' and
+	  'task sync' functions now correctly clear internal control bits before
+	  returning a value in every possible path through the respective functions.
+	+ Ensure the updating of internal control data is protected by a critical
+	  section after a task is deleted or suspended.
+	+ Minor fixes to FreeRTOS+FAT SL - namely seeking beyond the end of a file
+	  when the offset was not a multiple of the sector size.
+	+ Ensure Cortex-A9 system registers are only ever accessed as 32-bit values,
+	  even when only the lest significant byte of the register is implemented.
+
+	Other updates:
+
+	+ Updated the XMC4200 IAR project so it links with version 7.x of the IAR
+	  tools.
+	+ Add RL78L1C demo.
+	+ Add pcTimerGetName() API function.
+	+ Call _reclaim_reent() when a task is deleted if configUSE_NEWLIB_REENTRANT
+	  is defined.
+
+Changes between V7.6.0 and V8.0.0 released 19th Feb 2014
+
+	http://www.freertos.org/upgrading-to-FreeRTOS-V8.html
+
+	FreeRTOS V8.x.x is a drop-in compatible replacement for FreeRTOS V7.x.x,
+	although a change to the type used to reference character strings may result
+	in application code generating a few (easily clearable) compiler warnings
+	after the upgrade, and an updated typedef naming convention means use of the
+	old typedef names is now discouraged.
+	See http://www.freertos.org/upgrading-to-FreeRTOS-V8.html for full
+	information.
+
+	New features and functionality:
+
+	+ Event groups - see http://www.freertos.org/FreeRTOS-Event-Groups.html
+	+ Centralised deferred interrupt processing - see
+	  http://www.freertos.org/xTimerPendFunctionCallFromISR.html
+
+	Other updates:
+
+	+ Previously, when a task left the Blocked state, a context switch was
+	  performed if the priority of the unblocked task was greater than or equal
+	  to the priority of the Running task.  Now a context switch is only
+	  performed if the priority of the unblocked task is greater than the
+	  priority of the Running task.
+	+ New low power tickless demonstration project that targets the ST STM32L
+	  microcontroller - see
+	  http://www.freertos.org/STM32L-discovery-low-power-tickless-RTOS-demo.html
+	+ Add xPortGetMinimumEverFreeHeapSize() to heap_4.c.
+	+ Small change to the tickless low power implementation on the SAM4L to
+	  ensure the alarm value (compare match value) cannot be set to zero when a
+	  tickless period is exited due to an interrupt originating from a source
+	  other than the RTOS tick.
+	+ Update the GCC/Eclipse Win32 simulator demo to make better use of Eclipse
+	  resource filters and match the functionality of the MSVC equivalent.
+	+ xTaskIsTaskSuspended() is no longer a public function.  Use
+	  eTaskGetState() in its place.
+	+ Improved trace macros, including tracing of heap usage.
+	+ Remove one level of indirection when accepting interrupts on the PIC32MZ.
+	+ Add Cortex-A9 GCC port layer.
+	+ Add Xilinx Zynq demo application.
+
+
+Changes between V7.5.3 and V7.6.0 released 18th November 2013
+
+	V7.6.0 changes some behaviour when the co-operative scheduler is used (when
+	configUSE_PREEMPTION is set to 0).  It is important to note that the
+	behaviour of the pre-emptive scheduler is unchanged - the following
+	description only applies when configUSE_PREEMPTION is set to 0:
+
+	WHEN configUSE_PREEMPTION IS SET TO 0 (which is in a small minority of
+	cases) a context switch will now only occur when a task places itself into
+	the Blocked state, or explicitly calls taskYIELD().  This differs from
+	previous versions, where a context switch would also occur when implicitly
+	moving a higher priority task out of the Blocked state.  For example,
+	previously, WHEN PREEMPTION WAS TURNED OFF, if task A unblocks task B by
+	writing to a queue, then the scheduler would switch to the higher priority
+	task.  Now, WHEN PREEMPTION IS TURNED OFF, if task A unblocks task B by
+	writing to a queue, task B will not start running until task A enters the
+	Blocked state or task A calls taskYIELD().  [If configUSE_PREEMPTION is not
+	set to 0, so the normal pre-emptive scheduler is being used, then task B
+	will start running immediately that it is moved out of the Blocked state].
+
+	Other changes:
+
+	+ Added a port layer and a demo project for the new PIC32MZ architecture.
+	+ Update the PIC32MX port layer to re-introduce some ehb instructions that
+	  were previously removed, add the ability to catch interrupt stack
+	  overflows (previously only task stack overflows were trapped), and also
+	  add the ability to catch an application task incorrectly attempting to
+	  return from its implementing function.
+	+ Make dramatic improvements to the performance of the Win32 simulator port
+	  layer.
+	+ Ensure tasks that are blocked indefinitely report their state as Blocked
+	  instead of Suspended.
+	+ Slight improvement to the Cortex-M4F port layers where previously one
+	  register was inadvertently being saved twice.
+	+ Introduce the xSemaphoreCreateBinary() API function to ensure consistency
+	  in the semantics of how each semaphore type is created.  It is no longer
+	  recommended to use vSemaphoreCreateBinary() (the version prefixed with a
+	  'v'), although it will remain in the code for backward compatibility.
+	+ Update the Cortex-M0 port layers to allow the scheduler to be started
+	  without using the SVC handler.
+	+ Added a build configuration to the PIC32MX MPLAB X demo project that
+	  targets the PIC32 USB II starter kit.  Previously all the build
+	  configurations required the Explorer 16 hardware.
+	+ Some of the standard demo tasks have been updated to ensure they execute
+	  correctly with the updated co-operative scheduling behaviour.
+	+ Added comprehensive demo for the Atmel SAM4E, including use of
+	  FreeRTOS+UDP, FreeRTOS+FAT SL and FreeRTOS+CLI.
+
+	FreeRTOS+ Changes:
+
+	+ Minor maintenance on FreeRTOS+UDP.
+
+Changes between V7.5.2 and V7.5.3 released October 14 2013
+
+	Kernel changes:
+
+	+ Prior to V7.5.x yields requested from the tick hook would occur in the
+	  same tick interrupt - revert to that original behaviour.
+	+ New API function uxQueueSpacesAvailable().
+	+ Introduced the prvTaskExitError() function to Cortex-M0, Cortex-M3/4
+	  and Cortex-M4F ports.  prvTaskExitError() is used to trap tasks that
+	  attempt to return from their implementing functions (tasks should call
+	  vTaskDelete( NULL ); if they want to exit).
+	+ The Cortex-M0 version of portSET_INTERRUPT_MASK_FROM_ISR and
+	  portCLEAR_INTERRUPT_MASK_FROM_ISR are now fully nestable.
+	+ Improved behaviour and robustness of the default Cortex-M tickless idle
+	  behaviour.
+	+ Add workaround for silicon errata PMU_CM001 in Infineon XMC4000 devices to
+	  all Cortex-M4F ports.
+	+ Add Cortex-M0 port for Keil.
+	+ Updated Cortus port.
+	+ Ensure _impure_ptr is initialised before the scheduler is started.
+	  Previously it was not set until the first context switch.
+
+	FreeRTOS+ changes:
+
+	+ Update FreeRTOS+UDP to V1.0.1 - including direct integration of the
+	  FreeRTOS+Nabto task, improvements to the DHCP behaviour, and a correction
+	  to the test that prevents the network event hook being called on the first
+	  network down event.  The FreeRTOS+UDP change history is maintained
+	  separately.
+	+ Correct the __NVIC_PRIO_BITS setting in the LPC18xx.h header files
+	  provided in the NXP CMSIS library, then update the interrupts used by the
+	  LPC18xx demos accordingly.
+	+ Replace double quotes (") with single quotes (') in FreeRTOS+CLI help
+	  strings to ensure the strings can be used with the JSON descriptions used
+	  in the FreeRTOS+Nabto demos.
+
+	Demo and miscellaneous changes:
+
+	+ Added demo for the Atmel SAMD20 Cortex-M0+.  The demo includes
+	  FreeRTOS+CLI
+	+ Added a demo for the Infineon Cortex-M0 that can be built with the IAR
+	  Keil and GCC tools.
+	+ Updated the Infineon XMC4000 demos for IAR, Keil, GCC and Tasking tools,
+	  with additional build configurations to directly support the XMC4200 and
+	  XMC4400 devices, in addition to the previously supported XMC4500.
+	+ Updated the demo application.
+	+ Added additional trace macros traceMALLOC and traceFREE to track heap
+	  usage.
+
+Changes between V7.5.0 and V7.5.2 released July 24 2013
+
+	V7.5.2 makes the new Cortex-M vPortCheckInterruptPriority() function
+	compatible with the STM32 standard peripheral driver library, and adds
+	an extra critical section to the default low power tickless mode
+	implementation.  Only users of the STM32 peripheral library or the default
+	tickless implementation need update from version 7.5.0.
+
+Changes between V7.4.2 and V7.5.0 released July 19 2013
+
+	V7.5.0 is a major upgrade that includes multiple scheduling and efficiency
+	improvements, and some new API functions.
+
+	Compatibility information for FreeRTOS users:
+	  FreeRTOS V7.5.0 is backward compatible with FreeRTOS V7.4.0 with one
+	  exception; the vTaskList() and vTaskGetRunTimeStats() functions are now
+	  considered legacy, having been replaced by the single uxTaskGetSystemState()
+	  function.  configUSE_STATS_FORMATTING_FUNCTIONS must be set to 1 in
+	  FreeRTOSConfig.h for vTaskList() and vTaskGetRunTimeStats() to be
+	  available.
+
+	Compatibility information for FreeRTOS port writers:
+	  vTaskIncrementTick() is now called xTaskIncrementTick() (because it now
+	  returns a value).
+
+	Headline changes:
+
+	+ Multiple scheduling and efficiency improvements.
+	+ Core kernel files now pass PC-Lint V8 static checking without outputting
+	  any warnings (information on the test conditions will follow).
+
+	New API functions:
+
+	+ uxTaskGetSystemState() http://www.freertos.org/uxTaskGetSystemState.html
+	+ xQueueOverwrite() http://www.freertos.org/xQueueOverwrite.html
+	+ xQueueOverwriteFromISR()
+	+ xQueuePeekFromISR()
+
+	The following ports and demos, which were previously available separately,
+	are now incorporated into the main FreeRTOS zip file download:
+
+	+ ARM Cortex-A9 IAR
+	+ ARM Cortex-A9 ARM compiler
+	+ Renesas RZ
+	+ Microsemi SmartFusion2
+
+	New FreeRTOSConfig.h settings
+	http://shop.freertos.org/FreeRTOS_API_and_Configuration_Reference_s/1822.htm
+
+	+ configUSE_TIME_SLICING
+	+ configUSE_NEWLIB_REENTRANT
+	+ configUSE_STATS_FORMATTING_FUNCTIONS
+	+ configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS
+
+	Other changes:
+
+	+ (MPU port only) The configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS
+	  options provides a mechanism that allows application writers to execute
+	  certain functions in privileged mode even when a task is running in user
+	  mode.
+	+ Ports that support interrupt nesting now include a configASSERT() that
+	  will trigger if an interrupt safe FreeRTOS function is called from an
+	  interrupt that has a priority designated as above the maximum system/API
+	  call interrupt priority.
+	+ The included FreeRTOS+Trace recorder code has been updated to the latest
+	  version, and the demo applications that use the trace recorder code have
+	  been updated accordingly.
+	+ The FreeRTOS Windows Simulator (MSVC version only) has been updated to
+	  include a new basic 'blinky' build option in addition to the original
+	  comprehensive build option.
+	+ Improve RAM usage efficiency of heap_4.c and heap_2.c.
+	+ Prevent heap_4.c from attempting to free memory blocks that were not
+	  allocated by heap_4.c, or have already been freed.
+	+ As FreeRTOS now comes with FreeRTOS+FAT SL (donated by HCC) the Chan FATfs
+	  files have been removed from FreeRTOS/Demo/Common.
+	+ Fix build error when R4 port is build in co-operative mode.
+	+ Multiple port and demo application maintenance activities.
+
+Changes between V7.4.1 and V7.4.2 released May 1 2013
+
+	NOTE: There are no changes in the FreeRTOS kernel between V7.4.1 and V7.4.2
+
+	+ Added FreeRTOS+FAT SL source code and demo project.  The demo project
+	  runs in the FreeRTOS Windows simulator for easy and hardware independent
+	  experimentation and evaluation.  See http://www.FreeRTOS.org/fat_sl
+
+Changes between V7.4.0 and V7.4.1 released April 18 2013
+
+	+ To ensure strict conformance with the spec and ensure compatibility with
+	  future chips data and instruction barrier instructions have been added to
+	  the yield macros of Cortex-M and Cortex-R port layers.  For efficiency
+	  the Cortex-M port layer "yield" and "yield" from ISR are now implemented
+	  separately as the barrier instructions are not required in the ISR case.
+	+ Added FreeRTOS+UDP into main download.
+	+ Reorganised the FreeRTOS+ directory so it now matches the FreeRTOS
+	  directory with Source and Demo subdirectories.
+	+ Implemented the Berkeley sockets select() function in FreeRTOS+UDP.
+	+ Changed (unsigned) casting in calls to standard library functions with
+	  (size_t) casting.
+	+ Added the Atmel SAM4L and Renesas RX100 demos that demonstrates the
+	  tickless (tick suppression) low power FreeRTOS features.
+	+ Add a new RL78 IAR demo that targets numerous new RL78 chips and
+	  evaluation boards.
+	+ Adjusted stack alignment on RX200 ports to ensure an assert was not
+	  falsely triggered when configASSERT() is defined.
+	+ Updated the Cortex_M4F_Infineon_XMC4500_IAR demo to build with the latest
+	  version of EWARM.
+	+ Corrected header comments in the het.c and het.h files (RM48/TMS570 demo).
+
+
+Changes between V7.3.0 and V7.4.0 released February 20 2013
+
+	+ New feature:  Queue sets.  See:
+	  http://www.FreeRTOS.org/Pend-on-multiple-rtos-objects.html
+	+ Overhauled the default tickless idle mode implementation provided with the
+	  ARM Cortex-M3 port layers.
+	+ Enhanced tickless support in the core kernel code with the introduction of
+	  the configEXPECTED_IDLE_TIME_BEFORE_SLEEP macro and the
+	  eTaskConfirmSleepModeStatus() function.
+	+ Added the QueueSet.c common demo/test file.  Several demo applications
+	  have been updated to use the new demo/test tasks.
+	+ Removed reliance on the PLIB libraries from the MPLAB PIC32 port layer and
+	  demo applications.
+	+ Added the FreeRTOS+Trace recorder code to the MSVC Win32 demo.
+	+ Renamed eTaskStateGet() to eTaskGetState() for consistency, and added a
+	  pre-processor macro for backward compatibility with the previous name.
+	+ Updated functions implemented in the core queue.c source file to allow
+	  queue.h to be included from the .c file directly (this prevents compiler
+	  warnings that were generated by some compilers).
+	+ Updated the CCS Cortex-R4 port layer to replace the CLZ assembler function
+	  with the CLZ compiler intrinsic that is provided by the latest versions of
+	  the CCS ARM compiler.
+	+ Updated all heap_x.c implementations to replace the structure that was
+	  used to ensure the start of the heap was aligned with a more portable
+	  direct C code implementation.
+	+ Added support for PIC24 devices that include EDS.
+	+ Minor optimisations to the PIC32 port layer.
+	+ Minor changes to tasks.c that allow the state viewer plug-ins to display
+	  additional information.
+	+ Bug fix:  Update prvProcessReceivedCommands() in timers.c to remove an
+	  issue that could occur if the priority of the timer daemon task was set
+	  below the priority of tasks that used timer services.
+	+ Update the FreeRTOS+Trace recorder code to the latest version.
+
+Changes between V7.2.0 and V7.3.0 released October 31 2012
+
+	+ Added ability to override the default scheduler task selection mechanism
+	  with implementations that make use of architecture specific instructions.
+	+ Added ability to suppress tick interrupts during idle time, and in so
+	  doing, provide the ability to make use of architecture specific low power
+	  functionality.
+	+ Added the portSUPPRESS_TICKS_AND_SLEEP() macro and vTaskStepTick() helper
+	  function.
+	+ Added the configSYSTICK_CLOCK_HZ configuration constant.
+	+ Reworked the Cortex-M3 and Cortex-M4F port layers for GCC, Keil and IAR to
+	  directly support basic power saving functionality.
+	+ Added hooks to allow basic power saving to be augmented in the application
+	  by making use of chip specific functionality.
+	+ Minor change to allow mutex type semaphores to be used from interrupts
+	  (which would not be a normal usage model for a mutex).
+	+ Change the behaviour of the interrupt safe interrupt mask save and restore
+	  macros in the Cortex-M ports.  The save macro now returns the previous
+	  mask value.  The restore macro now uses the previous mask value.  These
+	  changes are not necessary for the kernel's own implementation, and are
+	  made purely because the macros were being used by application writers.
+	+ Added eTaskStateGet() API function.
+	+ Added port specific optimisations to the PIC32 port layer, and updated the
+	  PIC32 demo applications to make use of this new feature.
+	+ Added port specific optimisations to the Win32 simulator port.
+	+ Added new ports and demo applications for the TI Hercules RM48 and TMS570
+	  safety microcontrollers.
+	+ Added SAM3 demos targeting the ATSAM3S-EK2 and ATSAM3X-EK evaluation
+	  boards.
+	+ Updated the PIC32 MPLAB X project to manually set the compiler include
+	  paths instead of using the IDE entry box following reports that the
+	  include paths were somehow being deleted.
+	+ Improved character handling in FreeRTOS+CLI.
+
+Changes between V7.1.1 and V7.2.0 released 14 August 2012
+
+	FreeRTOS V7.2.0 is backward compatible with FreeRTOS V7.1.2.
+
+	+ Added a FreeRTOS+ sub-directory.  The directory contains some FreeRTOS+
+	  source code, and example projects that use the FreeRTOS Win32 simulator.
+	+ Added a new example heap allocation implementation (heap_4.c) that
+	  includes memory block coalescence.
+	+ Added a demo that targets the Atmel SAM4S Cortex-M4 based microcontroller.
+	  The demo is preconfigured to build using the free Atmel Studio 6 IDE and
+	  GCC compiler.
+	+ Added xSemaphoreTakeFromISR() implementation.
+	+ The last parameter in ISR safe FreeRTOS queue and semaphore functions
+	  (xHigherPriorityTaskWoken) is now optional and can be set to NULL if it
+	  is not required.
+	+ Update the IAR and MSP430X ports to clear all lower power mode bits before
+	  exiting the tick interrupt [bug fix].
+	+ Allow xQueueReset() to be used, even when the queues event lists are not
+	  empty.
+	+ Added a vQueueDelete() handler for the FreeRTOS MPU port (this was
+	  previously missing).
+	+ Updated the vPortSVCHandler() functions in the FreeRTOS MPU port layer to
+	  ensure it compiles with the latest ARM GCC compilers from Linaro.
+	+ Updated the prvReadGP() function in the NIOS II port to ensure the compiler
+	  can choose any register for the functions parameter (required at high
+	  compiler optimisation levels).
+	+ Add #error macros into the Keil and IAR Cortex-M ports to ensure they
+	  cannot be built if the user has set configMAX_SYSCALL_INTERRUPT_PRIORITY
+	  to 0.
+	+ Added comments in the FreeRTOSConfig.h files associated with Cortex-M3 and
+	  Cortex-M4 demos stating that the configMAX_SYSCALL_INTERRUPT_PRIORITY
+	  parameter must not be set to 0.
+	+ Introduce new INCLUDE_xQueueGetMutexHolder configuration constant
+	  (defaulted to 0).
+	+ Added two new list handling macros - for internal use only in upcoming new
+	  products.
+	+ Removed all mention of the legacy vTaskStartTrace and ulTaskEndTrace
+	  macros.  FreeRTOS+Trace supersedes the legacy trace.
+	+ Added a configASSERT() into the vPortFree() function in heap_1.c as it is
+	  invalid for the function to be called.
+	+ Made the xRxLock and xTxLock members of the queue structure volatile.
+	  This is probably not necessary, and is included as a precautionary
+	  measure.
+	+ Modify the assert() that checks to see if the priority passed into an
+	  xTaskCreate() function is within valid bounds to permit the assert to be
+	  used in the FreeRTOS MPU port.
+	+ The software timer service (daemon) task is now created in a way that
+	  to ensure compatibility with FreeRTOS MPU.
+
+Changes between V7.1.0 and V7.1.1 released May 1 2012
+
+	New ports:
+
+	The following ports are brand new:
+	+ Cortex-M3 Tasking
+
+	The following ports have been available as separate downloads for a number
+	of months, but are now included in the main FreeRTOS download.
+	+ Cortex-M0 IAR
+	+ Cortex-M0 GCC
+	+ Cortex-M4F GCC (with full floating point support)
+
+
+	New demos:
+
+	The following demos are brand new:
+	+ Renesas RX63N RDK (Renesas compiler)
+
+	The following demos have been available as separate downloads for a number
+	of months, but are now included in the main FreeRTOS download.
+	+ NXP LPC1114 GCC/LPCXpresso
+	+ ST STM32F0518 IAR
+	+ Infineon XMC4500 GCC/Atollic
+	+ Infineon XMC4500 IAR
+	+ Infineon XMC4500 Keil
+	+ Infineon XMC4500 Tasking
+
+
+	Kernel miscellaneous / maintenance:
+
+	+ Introduced the portSETUP_TCB() macro to remove the requirement for the
+	  Windows simulator to use the traceTASK_CREATE() macro, leaving the trace
+	  macro available for use by FreeRTOS+Trace (http://www.FreeRTOS.org/trace).
+	+ Added a new trace macro, traceMOVE_TASK_TO_READY_STATE(), to allow future
+	  FreeRTOS+Trace versions to provide even more information to users.
+	+ Updated the FreeRTOS MPU port to be correct for changes that were
+	  introduced in FreeRTOS V7.1.0.
+	+ Introduced the xQueueReset() API function.
+	+ Introduced the xSemaphoreGetMutexHolder() API function.
+	+ Tidy up various port implementations to add the static key word where
+	  appropriate, and remove obsolete code.
+	+ Slight change to the initial stack frame given to the RX600 ports to allow
+	  them to be used in the Eclipse based E2Studio IDE without confusing GDB.
+	+ Correct the alignment given to the initial stack of Cortex-M4F tasks.
+	+ Added a NOP following each DINT instruction on MSP430 devices for strict
+	  conformance with the instructions on using DINT.
+	+ Changed the implementation of thread deletes in the Win32 port to prevent
+	  the port making use of the traceTASK_DELETE() trace macros - leaving this
+	  macro free for use by FreeRTOS+Trace.
+	+ Made some benign changes to the RX600 Renesas compiler port layer to
+	  ensure the code can be built to a library without essential code being
+	  removed by the linker.
+	+ Reverted the change in the name of the uxTaskNumber variable made in
+	  V7.1.0 as it broke the IAR plug-in.
+
+
+	Demo miscellaneous / maintenance:
+
+	+ The command interpreter has now been formally released as FreeRTOS+CLI,
+	  and been moved out of the main FreeRTOS download, to instead be available
+	  from the FreeRTOS+ Ecosystem site http://www.FreeRTOS.org/plus.
+	+ flash_timer.c/h has been added to the list of standard demo tasks.  This
+	  performs the same functionality as the flash.c tasks, but using software
+	  timers in place of tasks.
+	+ Upgraded the PIC32 demo as follows:  Changes to how the library functions
+	  are called necessitated by the new compiler version, addition of MPLAB X
+	  project with PIC32MX360, PIC32MX460 and PIC32MX795 configurations,
+	  addition of simply blinky demo, updated FreeRTOSConfig.h to include more
+	  parameters, addition of hook function stubs.
+	+ The MSP430X IAR and CCS demos have been updated to ensure the power
+	  settings are correct for the configured CPU frequency.
+	+ Rowley CrossWorks projects have been updated to correct the "multiple
+	  definition of ..." warnings introduced when the toolchain was updated.
+	+ Updated various FreeRTOSConfig.h header files associated with projects
+	  that build with Eclipse to include a #error statement informing the user
+	  that the CreateProjectDirectoryStructure.bat batch file needs to be
+	  executed before the projects can be opened.
+	+ Renamed directories that included "CCS4" in their name to remove the '4'
+	  and instead just be "CCS".  This is because the demo was updated and
+	  tested to also work with later Code Composer Studio versions.
+	+ Updated the TCP/IP periodic timer frequency in numerous uIP demos to be
+	  50ms instead of 500ms.
+
+Changes between V7.0.2 and V7.1.0 released December 13 2011
+
+	New ports:
+
+	+ Cortex-M4F IAR port.
+	+ Cortex-M4F Keil/RVDS port.
+	+ TriCore GCC port.
+
+	New demos:
+
+	+ NXP LPC4350 using the Keil MDK, and demonstrated on a Hitex development
+	  board.
+	+ ST STM32F407 using the IAR Embedded Workbench for ARM, and demonstrated on
+	  the IAR STM32F407ZG-SK starter kit.
+	+ Infineon TriCore TC1782, using the GCC compiler, demonstrated on the
+	  TriBoard TC1782 evaluation board.
+	+ Renesas RX630, using the Renesas compiler and HEW, demonstrated on an
+	  RX630 RSK (Renesas Starter Kit).
+
+	Miscellaneous / maintenance:
+
+	+ Removed all calls to printf() from the K60/IAR Kinetis demo so the project
+	  can execute stand alone - without being connected to the debugger.
+	+ Completed the command interpreter framework.  Command handlers now receive
+	  the entire command string, giving them direct access to parameters.
+	  Utility functions are provided to check the number of parameters, and
+	  return parameter sub-strings.
+	+ The previously documented fix for the bug in xTaskResumeFromISR() that
+	  effected (only) ports supporting interrupt nesting has now been
+	  incorporated into the main release.
+	+ The portALIGNMENT_ASSERT_pxCurrentTCB() definition has been added to allow
+	  specific ports to skip the second stack alignment check when a task is
+	  created.  This is because the second check is not appropriate for some
+	  ports - including the new TriCore port where the checked pointer does not
+	  actually point to a stack.
+	+ The portCLEAN_UP_TCB() macro has been added to allow port specific clean
+	  up when a task is deleted - again this is required by the TriCore port.
+	+ Various other minor changes to ensure warning free builds on a growing
+	  number of microcontroller and toolchain platforms.  This includes a
+	  (benign) correction to the prototype of the
+	  vApplicationStackOverflowHook() definition found in lots of recent demos.
+
+	Trace system:
+
+	+ The legacy trace mechanism has been completely removed - it has been
+	  obsolete for the years since the trace macros were introduced.  The
+	  configuration constant configUSE_TRACE_FACILITY is now used to optionally
+	  include additional queue and task information.  The additional information
+	  is intended to make the trace mechanism more generic, and allow the trace
+	  output to provide more information.  When configUSE_TRACE_FACILITY is set
+	  to 1:
+		- the queue structure includes an additional member to hold the queue
+		  type, which can be base, mutex, counting semaphore, binary semaphore
+		  or recursive mutex.
+		- the queue structure includes an additional member to hold a queue
+		  number.  A trace tool can set and query the queue number for its own
+		  purposes.  The kernel does not use the queue number itself.
+		- the TCB structure includes an additional member to hold a task number
+		  number.  A trace tool can set and query the task number for its own
+		  purposes.  The kernel does not use the task number itself.
+	+ Queues and all types of semaphores are now automatically allocated their
+	  type as they are created.
+	+ Added two new trace macros - traceTASK_PRIORITY_INHERIT() and
+	  traskTASK_PRIORITY_DISINHERIT().
+	+ Updated the traceQUEUE_CREATE_FAILED() macro to take a parameter that
+	  indicates the type of queue, mutex, or semaphore that failed to be
+	  created.
+	+ The position from which traceCREATE_MUTEX() is called has been moved from
+	  after the call to xQueueGenericSend() [within the same function] to before
+	  the call.  This ensures the trace events occur in the correct order.
+	+ The value passed into tracePRIORITY_SET() has been corrected for the case
+	  where vTaskPrioritySet() is called with a null parameter.
+
+Changes between V7.0.1 and V7.0.2 released September 20 2011
+
+	New ports:
+
+	+ The official FreeRTOS Renesas RX200 port and demo application have been
+	  incorporated into the main FreeRTOS zip file download.
+	+ The official FreeRTOS Renesas RL78 port and demo application have been
+	  incorporated into the main FreeRTOS zip file download.
+	+ The official FreeRTOS Freescale Kinetis K60 tower demo application has
+	  been incorporated into the main FreeRTOS zip file download.  This includes
+	  an embedded web server example.
+	+ A new Microblaze V8 port layer has been created to replace the older, now
+	  deprecated, port layer.  The V8 port supports V8.x of the Microblaze IP,
+	  including exceptions, caches, and the floating point unit.  A new
+	  Microblaze demo has also been added to demonstrate the new Microblaze V8
+	  port layer.  The demo application was created using V13.1 of the Xilinx
+	  EDK, and includes a basic embedded web server that uses lwIP V1.4.0.
+	+ The official FreeRTOS Fujitsu FM3 MB9A310 demo application has been
+	  incorporated into the main FreeRTOS zip file download.  Projects are
+	  provided for both the IAR and Keil toolchains.
+
+
+	API additions:
+
+	+ xTaskGetIdleTaskHandle() has been added.
+	+ xTaskGetTimerDaemonTaskHandle() has been added.
+	+ pcTaskGetTaskName() has been added.
+	+ vSemaphoreDelete() macro has been added to make it obvious how to delete
+	  a semaphore.  In previous versions vQueueDelete() had to be used.
+	+ vTaskCleanUpResources() has been removed.  It has been obsolete for a
+	  while.
+	+ portPOINTER_SIZE_TYPE has been introduced to prevent compiler warnings
+	  being generated when the size of a pointer does not match the size of
+	  the stack type.  This will (has already) be used in new ports, but will
+	  not be retrofitted to existing ports until the existing port itself is
+	  updated.
+
+	Other updates and news:
+
+	+ The core files have all been modified to tighten the coding standard even
+	  further.  These are style, not functional changes.
+	+ All ARM7 port layers have been slightly modified to prevent erroneous
+	  assert() failures when tasks are created and configASSERT() is defined.
+	+ All ARM IAR projects have been updated to build with the latest V6.2.x
+	  versions of the IAR Embedded Workbench for ARM tools (EWARM).  This was
+	  necessary due to a change in the way EWARM uses the CMSIS libraries.
+	+ The PIC32 port layer has been updated in preparation for V2 of the C32
+	  compiler.
+	+ The old Virtex-4 Microblaze demo has been marked as deprecated.  Please
+	  use the brand new Spartan-6 port and demo in its place.
+	+ The bones of a new generic command interpreter is located in
+	  FreeRTOS/Demo/Common/Utils/CommandInterpreter.c.  This is still a work in
+	  progress, and not documented.  It is however already in use.  It will be
+	  documented in full when the projects that are already using it are
+	  completed.
+	+ A couple of new standard demos have been included.  First, a version of
+	  flop.c called sp_flop.c.  This is similar to flop.c, but uses single
+	  precision floats in place of double precision doubles.  This allows the
+	  for testing ports to processors that have only single precision floating
+	  point units, and revert to using emulated calculations whenever a double
+	  is used.  Second, comtest_strings.c has been included to allow the test
+	  of UART drivers when an entire string is transmitted at once.  The
+	  previous comtest.c only used single character transmission and reception.
+	+ lwIP V1.4.0 is now included in the FreeRTOS/Demo/Common directory, and
+	  used by a couple of new demos.
+
+Changes between V7.0.0 and V7.0.1 released May 13 2011
+
+	+ Added a Fujitsu FM3 demo application for both the IAR and Keil tool
+	  chains.
+	+ Added a SmartFusion demo application for all of the IAR, Keil and
+	  SoftConsole (GCC/Eclipse) tool chains.
+	+ Updated the RX600 port and demo applications to take into account the
+	  different semantics required when using the latest (V1.0.2.0) version of
+	  the Renesas compiler.
+	+ Modified the RX600 Ethernet driver slightly to make it more robust under
+	  heavy load, and updated the uIP handling task to make use of the FreeRTOS
+	  software timers.
+	+ Slightly changed the PIC32 port layer to move an ehb instruction in line
+	  with the recommendations of the MIPS core manual, and ensure 8 byte stack
+	  alignment is truly always obtained.
+	+ Changed the behaviour when tasks are suspended before the scheduler has
+	  been started.  Before, there needed to be at least one task that was not
+	  in the suspended state.  This is no longer the case.
+
+Changes between V6.1.1 and V7.0.0 released April 8 2011
+
+	FreeRTOS V7.0.0 is backward compatible with FreeRTOS V6.x.x
+
+	Main changes:
+
+	+ Introduced a new software timer implementation.
+	+ Introduced a new common demo application file to exercise the new timer
+	  implementation.
+	+ Updated the Win32/MSVC simulator project to include the new software timer
+	  demo tasks and software timer tick hook test.  Much simpler software timer
+	  demonstrations are included in the demo projects for both of the new ports
+	  (MSP430X with CCS4 and STM32 with TrueStudio).
+	+ Various enhancements to the kernel implementation in tasks.c.  These are
+	  transparent to users and do not effect the pre-existing API.
+	+ Added calls to configASSERT() within the kernel code.  configASSERT() is
+	  functionally equivalent to the standard C assert() macro, but does not
+	  rely on the compiler providing assert.h.
+
+	Other changes:
+
+	+ Updated the MSP430X IAR port and demo project to include support for the
+	  medium memory model.
+	+ Added a demo project for the MSP430X that targets the MSP430X Discovery
+	  board and uses the Code Composer Studio 4 tools.  This demo includes use
+	  of the new software timer implementation.
+	+ Added an STM32F100RB demo project that targets the STM32 Discovery Board
+	  and uses the TrueStudio Eclipse based IDE from Atollic.
+	+ Removed some compiler warnings from the PSoC demo application.
+	+ Updated the PIC32 port layer to ensure the
+	  configMAX_SYSCALL_INTERRUPT_PRIORITY constant works as expected no matter
+	  what its value is (within the valid range set by the microcontroller
+	  kernel).
+	+ Updated the PIC24, dsPIC and PIC32 projects so they work with the latest
+	  MPLAB compiler versions from Microchip.
+	+ Various cosmetic changes to prepare for a standards compliance statement
+	  that will be published after the software release.
+
+
+Changes between V6.1.0 and V6.1.1 released January 14 2011
+
+	+ Added two new Windows simulator ports.  One uses the free Microsoft Visual
+	  Studio 2010 express edition, and the other the free MingW/Eclipse
+	  environment.  Demo projects are provided for both.
+	+ Added three demo projects for the PSoC 5 (CYAC5588).  These are for the
+	  GCC, Keil, and RVDS build tools, and all use the PSoC Creator IDE.
+	+ Added a demo for the low power STM32L152 microcontroller using the IAR
+	  Embedded Workbench.
+	+ Added a new port for the MSP430X core using the IAR Embedded Workbench.
+	+ Updated all the RX62N demo projects that target the Renesas Demonstration
+	  Kit (RDK) to take into account the revered LED wiring on later hardware
+	  revisions, and the new J-Link debug interface DLL.
+	+ Updated all the RX62N demo projects so the IO page served by the example
+	  embedded web server works with all web browsers.
+	+ Updated the Red Suite projects to work with the up coming Red Suite
+	  release, and to use a more recent version of the CMSIS libraries.
+	+ Added the traceTAKE_MUTEX_RECURSIVE_FAILED() trace macro.
+	+ Removed the (pointless) parameter from the traceTASK_CREATE_FAILED()
+	  trace macro.
+	+ Introduced the portALT_GET_RUN_TIME_COUNTER_VALUE() macro to compliment
+	  the already existing portGET_RUN_TIME_COUNTER_VALUE().  This allows for
+	  more flexibility in how the time base for the run time statistics feature
+	  can be implemented.
+	+ Added a "cpsie i" instruction before the "svc 0" instruction used to start
+	  the scheduler in each of the Cortex M3 ports.  This is to ensure that
+	  interrupts are globally enabled prior to the "svc 0" instruction being
+	  executed in cases where interrupts are left disabled by the C start up
+	  code.
+	+ Slight optimisation in the run time stats calculation.
+
+Changes between V6.0.5 and V6.1.0 released October 6 2010
+
+	+ Added xTaskGetTickCountFromISR() function.
+	+ Modified vTaskSuspend() to allow tasks that have just been created to be
+	  immediately suspended even when the kernel has not been started.  This
+	  allows them to effectively start in the Suspended state - a feature that
+	  has been asked for on numerous occasions to assist with initialisation
+	  procedures.
+	+ Added ports for the Renesas RX62N using IAR, GCC and Renesas tool suites.
+	+ Added a STM32F103 demo application that uses the Rowley tools.
+	+ Under specific conditions xFreeBytesRemaining within heap_2.c could end up
+	  with an incorrect	value.  This has been fixed.
+	+ xTaskCreateGeneric() has a parameter that can be used to pass the handle
+	  of the task just created out to the calling task.  The assignment to this
+	  parameter has been moved to ensure it is assigned prior to the newly
+	  created having any possibility of executing.  This takes into account the
+	  case where the assignment is made to a global variable that is accessed by
+	  the newly created task.
+	+ Fixed some build time compiler warnings in various FreeTCPIP (based on
+	  uIP) files.
+	+ Fixed some build time compiler warnings in Demo/Common/Minimal/IntQueue.c.
+
+Changes between V6.0.4 and V6.0.5 released May 17 2010
+
+	+ Added port and demo application for the Cortus APS3 processor.
+
+Changes between V6.0.3 and V6.0.4 released March 14 2010
+
+	+ All the contributed files that were located in the Demo/Unsupported_Demos
+	  directory have been removed.  These files are instead now available in the
+	  new  Community Contributions section of the FreeRTOS website.  See
+	  http://www.freertos.org/RTOS-contributed-ports.html
+	+ The project file located in the Demo/CORTEX_STM32F107_GCC_Rowley directory
+	  has been upgraded to use V2.x of the Rowley Crossworks STM32 support
+	  package.
+	+ An initial Energy Micro EFM32 demo has been included.  This will be
+	  updated over the coming months to make better use of the low power modes
+	  the EFM32 provides.
+
+Changes between V6.0.2 and V6.0.3 released February 26 2010
+
+	+ SuperH SH7216 (SH2A-FPU) port and demo application added.
+	+ Slight modification made to the default implementation of
+	  pvPortMallocAligned() and vPortFreeAligned() macros so by default they
+	  just call pvPortMalloc() and vPortFree().  The macros are only needed to
+	  be defined when a memory protection unit (MPU) is being used - and then
+	  only depending on other configuration settings.
+
+Changes between V6.0.1 and V6.0.2 released January 9th 2010
+
+	+ Changed all GCC ARM 7 ports to use 0 as the SWI instruction parameter.
+	  Previously the parameter was blank and therefore only an implicit 0 but
+	  newer GCC releases do not permit this.
+	+ Updated IAR SAM7S and SAM7X ports to work with IAR V5.40.
+	+ Changed the stack alignment requirement for PIC32 from 4 bytes to 8 bytes.
+	+ Updated prvListTaskWithinSingleList() is it works on processors where the
+	  stack grows up from low memory.
+	+ Corrected some comments.
+	+ Updated the startup file for the RVDS LPC21xx demo.
+
+Changes between V6.0.0 and V6.0.1 released November 15th 2009
+
+	+ Altered pxPortInitialiseStack() for all Cortex-M3 ports to ensure the
+	  stack pointer is where the compiler expects it to be when a task first
+	  starts executing.
+
+	  The following minor changes only effect the Cortex-M3 MPU port:
+
+	+ portRESET_PRIVILEGE() assembly macro updated to include a clobber list.
+	+ Added prototypes for all the privileged function wrappers to ensure no
+	  compile time warnings are generated no matter what the warning level
+	  setting.
+	+ Corrected the name of portSVC_prvRaisePrivilege to
+	  portSVC_RAISE_PRIVILEGE.
+	+ Added conditional compilation into xTaskGenericCreate() to prevent some
+	  compilers issuing warnings when portPRIVILEGE_BIT is defined as zero.
+
+
+Changes between V5.4.2 and V6.0.0 released October 16th 2009
+
+	FreeRTOS V6 is backward compatible with FreeRTOS V5.x.
+
+	Main changes:
+
+	+ FreeRTOS V6 is the first version to include memory protection unit (MPU)
+	  support.  Two ports now exist for the Cortex M3, the standard FreeRTOS
+	  which does not include MPU support, and FreeRTOS-MPU which does.
+	+ xTaskCreateRestricted() and vTaskAllocateMPURegions() API functions added
+	  in support of FreeRTOS-MPU.
+	+ Wording for the GPL exception has been (hopefully) clarified.  Also the
+	  license.txt file included in the download has been fixed (the previous
+	  version contained some corruption).
+
+	Other changes:
+
+	+ New API function xPortGetFreeHeapSize() added to heap_1.c and heap_2.c.
+	+ ARM7 GCC demo interrupt service routines wrappers have been modified to
+	  call the C portion using an __asm statement.  This prevents the function
+	  call being inlined at higher optimisation levels.
+	+ ARM7 ports now automatically set the THUMB bit if necessary when
+	  setting up the initial stack of a task - removing the need for
+	  THUMB_INTERWORK to be defined.  This also allows THUMB mode and ARM mode
+	  tasks to be mixed more easily.
+	+ All ARM7/9 ports now have portBYTE_ALIGNMENT set to 8 by default.
+	+ Various demo application project files have been updated to be up to date
+	  with the latest IDE versions.
+	+ The linker scripts used with command line GCC demos have been updated to
+	  include an eh_frame section to allow their use with the latest Yagarto
+	  release.  Likewise the demo makefiles have been updated to include
+	  command line options to reduce or eliminate the eh_frame section all
+	  together.
+	+ The definition of portBYTE_ALIGNMENT_MASK has been moved out of the
+	  various memory allocation files and into the common portable.h header
+	  file.
+	+ Removed unnecessary use of portLONG, portSHORT and portCHAR.
+	+ Added LM3Sxxxx demo for Rowley CrossWorks.
+	+ Posix simulator has been upgraded - see the corresponding WEB page on the
+	  FreeRTOS.org site.
+
+
+Changes between V5.4.1 and V5.4.2 released August 9th 2009
+
+	+ Added a new port and demo app for the Altera Nios2 soft core.
+	+ Added LPC1768 demo for IAR.
+	+ Added a USB CDC demo to all LPC1768 demos (Code Red, CrossWorks and IAR).
+	+ Changed clock frequency of LPC1768 demos to 99MHz.
+
+Changes between V5.4.0 and V5.4.1 released July 25th 2009
+
+	+ New hook function added.  vApplicationMallocFailedHook() is (optionally)
+	  called if pvPortMalloc() returns NULL.
+	+ Additional casting added to xTaskCheckForTimeOut().  This prevents
+	  problems that can arise should configUSE_16_BIT_TICKS be set to 1 on a
+	  32 bit architecture (which would probably be a mistake, anyway).
+	+ Corrected the parameter passed to NVIC_SetPriority() to set the MAC
+	  interrupt priority in both LPC1768 demos.
+	+ Decreased the default setting of configMINIMAL_STACK_SIZE in the PIC32
+	  demo application to ensure the heap space was not completely consumed
+	  before the scheduler was started.
+
+Changes between V5.3.1 and V5.4.0 released July 13th 2009
+
+	+ Added Virtex5 / PPC440 port and demos.
+	+ Replaced the LPC1766 Red Suite demo with an LPC1768 Red Suite demo.  The
+	  original demo was configured to use engineering samples of the CPU.  The
+	  new demo has an improved Ethernet driver.
+	+ Added LPC1768 Rowley demo with zero copy Ethernet driver.
+	+ Reworked byte alignment code to ensure 8 byte alignment works correctly.
+	+ Set configUSE_16_BIT_TICKS to 0 in the PPC405 demo projects.
+	+ Changed the initial stack setup for the PPC405 to ensure the small data
+	  area pointers are setup correctly.
+
+Changes between V5.3.0 and V5.3.1 released June 21st 2009
+
+	+ Added ColdFire V1 MCF51CN128 port and WEB server demo.
+	+ Added STM32 Connectivity Line STM32107 Cortex M3 WEB server demo.
+	+ Changed the Cortex M3 port.c asm statements to __asm so it can be
+	  compiled using Rowley CrossWorks V2 in its default configuration.
+	+ Updated the Posix/Linux simulator contributed port.
+
+Changes between V5.2.0 and V5.3.0 released June 1st 2009
+
+	Main changes:
+
+	+ Added new (optional) feature that gathers statistics on the amount of CPU
+	  time used by each task.
+	+ Added a new demo application for the Atmel AT91SAM3U Cortex-M3 based
+	  microcontroller.
+	+ Added a new demo application for the NXP LPC1766 Cortex-M3 based
+	  microcontroller.
+	+ Added a contributed port/demo that allows FreeRTOS to be 'simulated' in a
+	  Linux environment.
+
+	Minor changes:
+	+ Updated the Stellaris uIP WEB server demos to include the new run time
+	  statistics gathering feature - and include a served WEB page that
+	  presents the information in a tabular format.
+	+ Added in the lwIP port layer for the Coldfire MCF52259.
+	+ Updated the CrossWorks LPC2368 WEB server to include an image in the
+	  served content.
+	+ Changed some of the timing in the initialisation of the LPC2368 MAC to
+	  permit its use on all part revisions.
+	+ Minor modifications to the core uIP code to remove some compiler warnings.
+	+ Added xTaskGetApplicationTaskTag() function and updated the OpenWatcom
+	  demo to make use of the new function.
+	+ Added contributed demos for AVR32 AP7000, STM32 Primer 2 and STM32 using
+	  Rowley Crossworks.
+	+ Heap_1.c and Heap_2.c used to define structures for the purpose of data
+	  alignment.  These have been converted to unions to save a few bytes of
+	  RAM that would otherwise be wasted.
+	+ Remove the call to strncpy() used to copy the task name into the TCB when
+	  the maximum task name is configured to be 1 byte long.
+
+Changes between V5.1.2 and V5.2.0 released March 14th 2009
+
+	+ Optimised the queue send and receive functions (also used by semaphores).
+	+ Replaced the standard critical sections used to protect BIOS calls in the
+	  PC port to instead use scheduler locks.  This is because the BIOS calls
+	  always return with interrupts enabled.
+	+ Corrected unclosed comments in boot.s.
+
+Changes between V5.1.1 and V5.1.2 released February 9th 2009
+
+	+ Added NEC V850ES port and demo.
+	+ Added NEC 78K0R port and demo.
+	+ Added MCF52259 port and demo.
+	+ Added the AT91SAM9XE port and demo.
+	+ Updated the MCF52233 FEC driver to work around a silicon bug that
+	  prevents the part auto negotiating some network parameters.
+	+ Minor modifications to the MCF52233 makefile to permit it to be used
+	  on Linux hosts.
+	+ Updated the STM32 primer files to allow them to be built with the latest
+	  version of the RIDE tools.
+	+ Updated the threads.js Java script used for kernel aware debugging in
+	  the Rowley CrossWorks IDE.
+
+
+Changes between V5.1.0 and V5.1.1 released November 20, 2008
+
+	+ Added Coldfire MCF52233 WEB server demo using GCC and Eclipse.
+	+ Added IAR MSP430 port and demo.
+	+ Corrected several compiler time issues that had crept in as tool versions
+	  change.
+	+ Included FreeRTOS-uIP - a faster uIP.  This is not yet complete.
+
+Changes between V5.0.4 and V5.1.0 released October 24, 2008
+
+	+ Added a new port and demo application for the ColdFire V2 core using the
+	  CodeWarrior development tools.
+	+ Replaced the ARM7 demo that used the old (and now no longer supported)
+	  Keil compiler with a new port that uses the new Keil/RVDS combo.
+	+ Stack overflow checking now works for stacks that grow up from low
+	  memory (PIC24 and dsPIC).
+	+ BUG FIX - set the PIC32 definition of portSTACK_GROWTH to the correct
+	  value of -1.
+	+ MSP430 port layers have been updated to permit tasks to place the
+	  microcontroller into power down modes 1 to 3.  The demo applications have
+	  likewise been updated to demonstrate the new feature.
+	+ Replaced the two separate MSP430/Rowley port layers with a single and more
+	  flexible version.
+	+ Added more contributed ports, including ports for NEC and SAM9
+	  microcontrollers.
+	+ Changed the linker script used in the LPC2368 Eclipse demo.
+
+Changes between V5.0.3 and V5.0.4 released September 22, 2008
+
+	+ Completely re-written port for ColdFire GCC.
+	+ Bug fix:  All Cortex M3 ports have a minor change to the code that sets
+	  the pending interrupt.
+	+ Some header files require that FreeRTOS.h be included prior to their
+	  inclusion.  #error message have been added to all such header file
+	  informing users to the cause of the compilation error should the headers
+	  not be included in the correct order.
+
+Changes between V5.0.2 and V5.0.3 released July 31, 2008
+
+	Changes relating to the Cortex M3:
+
+	+ Added configMAX_SYSCALL_INTERRUPT_PRIORITY usage to all the Cortex M3
+	  ports and demos.  See the port documentation pages on the FreeRTOS.org
+	  WEB site for full usage information.
+	+ Improved efficiency of Cortex M3 port even further.
+	+ Ensure the Cortex M3 port works no matter where the vector table is
+	  located.
+	+ Added the IntQTimer demo/test tasks to a demo project for each CM3 port
+	  (Keil, GCC and IAR) to test the new configMAX_SYSCALL_INTERRUPT_PRIORITY
+	  functionality.
+	+ Added the mainINCLUDE_WEB_SERVER definition to the LM3SXXXX IAR and Keil
+	  projects to allow the WEB server to be conditionally excluded from the
+	  build and therefore allow use of the KickStart (code size limited)
+	  compiler version.
+
+	Other changes:
+
+	+ Moved the PIC24 and dsPIC versions of vPortYield() from the C file to
+	  an assembly file to allow use with all MPLAB compiler versions.  This also
+	  allows the omit-frame-pointer optimisation to be turned off.
+
+Changes between V5.0.0 and V5.0.2 released May 30, 2008
+
+	+ Updated the PIC32 port to allow queue API calls to be used from
+	  interrupts above the kernel interrupt priority, and to allow full
+	  interrupt nesting.  Task stack usages has also been reduced.
+	+ Added a new PowerPC port that demonstrates how the trace macros can be
+	  used to allow the use of a floating point co-processor.  The
+	  traceTASK_SWITCHED_OUT() and traceTASK_SWITCHED_INT() macros are used to
+	  save and restore the floating point context respectively for those tasks
+	  that actually use floating point operations.
+	+ BUG FIX:  The first PPC405 port contained a bug in that it did not leave
+	  adequate space above the stack for the backchain to be saved when a task
+	  started to execute for the first time.
+	+ Updated queue.c to add in the means to allow interrupt nesting and for
+	  queue API functions to be called from interrupts that have a priority
+	  above the kernel priority.  This is only supported on PIC32 ports thus
+	  far.
+	+ Fixed the compiler warnings that were generated when the latest version
+	  of WinAVR was used.
+	+ Remove all inline usage of 'inline' from the core kernel code.
+	+ Added the queue registry feature.  The queue registry is provided as a
+	  means for kernel aware debuggers to locate queue definitions.  It has no
+	  purpose unless you are using a kernel aware debugger.  The queue registry
+	  will only be used when configQUEUE_REGISTRY_SIZE is greater than zero.
+	+ Added the ST Cortex-M3 drivers into the Demo/Common/Drivers directory to
+	  prevent them from having to be included in multiple demos.
+	+ Added a Keil STM32 demo application.
+	+ Changed the blocktim.c test files as it is no longer legitimate for all
+	  ports to call queue API functions from within a critical section.
+	+ Added the IntQueue.c test file to test the calling of queue API functions
+	  from different interrupt priority levels, and test interrupt nesting.
+
+Changes between V5.0.0 and V5.0.1
+
+	+ V5.0.1 was a customer specific release.
+
+Changes between V4.8.0 and V5.0.0 released April 15, 2008
+
+	*** VERY IMPORTANT INFORMATION ON UPGRADING TO FREERTOS.ORG V5.0.0 ***
+
+	The parameters to the functions xQueueSendFromISR(), xQueueSendToFrontFromISR(),
+	xQueueSendToBackFromISR() and xSemaphoreGiveFromISR() have changed.  You must
+	update all calls to these functions to use the new calling convention!  Your
+	compiler might not issue any type mismatch warnings!
+
+
+	See http://www.FreeRTOS.org/upgrading.html for full information.
+
+
+	Other changes:
+
+	+ Support added for the new Luminary Micro LM3S3768 and LM3S3748 Cortex-M3
+	  microcontrollers.
+	+ New task hook feature added.
+	+ PowerPC demo updated to use version 10.1 of the Xilinx EDK.
+	+ Efficiency gains within the PIC32 port layer.
+
+Changes between V4.7.2 and V4.8.0 released March 26 2008
+
+	+ Added a Virtex4 PowerPC 405 port and demo application.
+	+ Added optional stack overflow checking and new
+	  uxTaskGetStackHighWaterMark() function.
+	+ Added new xQueueIsQueueEmptyFromISR(), xQueueIsQueueFullFromISR() and
+	  uxQueueMessagesWaitingFromISR() API functions.
+	+ Efficiency improvements to the Cortex-M3 port layer.  NOTE: This
+	  requires that an SVC handler be installed in the application.
+	+ Efficiency improvements to the queue send and receive functions.
+	+ Added new trace macros.  These are application definable to provide
+	  a flexible trace facility.
+	+ Implemented the configKERNEL_INTERRUPT_PRIORITY within the Keil Cortex
+	  M3 port layer (bringing it up to the same standard as the IAR and GCC
+	  versions).
+	+ Ports that used the arm-stellaris-eabi-gcc tools have been converted to
+	  use the arm-non-eabi-gcc tools.
+
+Changes between V4.7.1 and V4.7.2 released February 21, 2008
+
+	+ Added Fujitsu MB91460 port and demo.
+	+ Added Fujitsu MB96340 port and demo.
+	+ Tidied up the capitalisation of include files to facilitate builds on
+	  Linux hosts.
+	+ Removed some redundant casting that was generating warnings - but was
+	  included to remove warnings on other compilers.
+
+Changes between V4.7.0 and V4.7.1 released February 3, 2008
+
+	+ Updated all IAR ARM projects to use V5.11 of the IAR Embedded Workbench
+	  for ARM.
+	+ Introduced recursive semaphore feature.
+	+ Updated LPC2368 demos to take into account silicon bugs in old chip
+	  revisions.
+	+ Updated STR9 uIP port to manually set the net mask and gateway addresses.
+	+ Updating demos to allow more to run with the co-operative scheduler.
+	+ Fixed co-operative scheduler behaviour upon the occurrence of a tick
+	  interrupt while the scheduler was suspended.
+	+ Updated documentation contained within semphr.h.
+	+ ARM7 GCC ports no longer use the IRQ attribute.
+
+Changes between V4.6.1 and V4.7.0 released December 6, 2007
+
+	+ Introduced the counting semaphore macros and demo source files.  The
+          Open Watcom PC project has been updated to include the new demo.  See
+          the online documentation for more information.
+	+ Introduced the 'alternative' queue handling API and demo source files.
+	  The Open Watcom PC project has been updated to include the new demo
+	  source files.  See the online documentation for more information.
+	+ Added AT91SAM7X Eclipse demo project.
+	+ Added the STM32 primer demo project for the GCC compiler and Ride IDE.
+	+ Removed the .lock files that were mistakenly included in the V4.6.1
+	  eclipse workspaces.
+
+Changes between V4.6.0 and V4.6.1 released November 5 2007
+
+	+ Added support for the MIPS M4K based PIC32.
+	+ Added 'extern "C"' to all the header files to facilitate use with C++.
+
+Changes between V4.5.0 and V4.6.0 released October 28 2007
+
+	+ Changed the method used to force a context switch within an ISR for the
+	  ARM7/9 GCC ports only.  The portENTER_SWITCHING_ISR() and
+	  portEXIT_SWITCHING_ISR() macros are no longer supported.  This is to
+	  ensure correct behaviour no matter which GCC version is used, with or
+	  without the -fomit-frame-pointer option, and at all optimisation levels.
+	+ Corrected the prototype for xQueueGenericSend() within queue.h.
+
+Changes between V4.4.0 and V4.5.0 released September 17 2007
+
+	+ Added the xQueueSendToFront(), xQueueSendToBack() and xQueuePeek()
+	  functionality.  These should now be used in preference to the old
+	  xQueueSend() function - which is maintained for backward compatibility.
+	+ Added Mutex functionality.  The behaviour of mutexes is subtly different
+	  to the already existing binary semaphores as mutexes automatically
+	  include a priority inheritance mechanism.
+	+ Added the GenQTest.c and QPeek.c to test and demonstrate the behaviour
+	  of the new functionality.
+	+ Updated the LM3Sxxxx and PC ports to include the new GenQTest.c and
+	  QPeek.c files.
+	+ Updated the GCC port for the Cortex M3 to include the
+	  configKERNEL_INTERRUPT_PRIORITY functionality.  This was previously only
+	  included in the IAR port.
+	+ Optimised the GCC and IAR port layer code - specifically the context
+	  switch code.
+	+ Consolidated the LM3Sxxxx EK demos for all development tools into a
+	  single project that automatically detects which version of the EK the
+	  application is executing on.
+	+ Added Eclipse support for LM3Sxxxx evaluation kits.
+	+ Added Eclipse support for the Keil LPC2368 evaluation kit.
+	+ Added the Demo/Drivers directory to hold code that is common to multiple
+	  demo application projects.
+	+ Included some minor bug fixes in the uIP 1.0 code.
+	+ Added an lwIP demo for the STR9 - thanks ST for assistance.
+	+ Updated the AVR32 port to ensure correct behaviour with full compiler
+	  optimisation.
+	+ Included binaries for OpenOCD FTDI and parallel port interfaces.
+
+Changes between V4.4.0 and V4.3.1 released July 31, 2007
+
+	+ Added AVR32 UC3B demo application.
+	+ Updated AVR32 UC3A port and demo applications.
+	+ Added IAR lwIP demo for AVR32 UC3A.
+	+ Updated listGET_OWNER_OF_NEXT_ENTRY() to assist compiler optimisation
+	  (thanks Niu Yong for making the suggestion).
+	+ Added xTaskGetSchedulerState() API function.
+	+ BUG FIX:  Corrected behaviour when tasks that are blocked indefinitely
+	  have their block time adjusted (within xQueueSend() and xQueueReceive()),
+	  and are the subject of a call the vTaskResume() when they are not
+	  actually in the Suspended state (thanks Dan Searles for reporting the
+	  issues).
+
+
+Changes between V4.3.0 and V4.3.1 released June 11, 2007
+
+	+ Added STMicroelectronics STM32 Cortex-M3 demo application.
+	+ Updated ustdlib.c for the GCC LM3S6965 demo.
+
+Changes between V4.2.1 and V4.3.0 released June 5, 2007
+
+	+ Introduced configKERNEL_INTERRUPT_PRIORITY to the IAR Cortex-M3, PIC24
+	  and dsPIC ports.  See the LM3S6965 and PIC24 demo application
+	  documentation pages for more information.
+	+ Updated the PIC24 and dsPIC demos to build with V3.0 of the PIC30 GCC
+	  tools, and changed the demo applications.
+	+ Added demos for the new Ethernet and CAN enabled Luminary Micro Stellaris
+	  microcontrollers.
+	+ Corrected bug in uIP the demos that prevented frames of approximately 1480
+	  bytes and over from being transmitted.
+	+ Included the LPC2368/uIP/Rowley demo into the main FreeRTOS.org
+	  download.
+	+ Update to WizC PIC18 port to permit its use with version 14 of the
+	  compiler.  Thanks Marcel!
+
+Changes between V4.2.1 and V4.2.0 released April 2, 2007
+
+	+ Added AVR32 AT32UC3A ports for GCC and IAR.
+	+ Added -fomit-frame-pointer option to lwIP SAM7X demo makefile.
+	+ Moved location of call to LCD_Init() in STR9 demo to ensure it is only
+	  called after the scheduler has been started.
+
+Changes between V4.1.3 and V4.2.0 released February 8, 2007
+
+	+ Changes to both task.c and queue.c as a result of testing performed on
+	  the SafeRTOS code base.
+	+ Added Cortex-M3 LM3S811 demos for GCC and IAR tools.
+
+Changes between V4.1.2 and V4.1.3 released November 19, 2006
+
+	+ Added STR750 ARM7 port using the Raisonance RIDE/GCC tools.
+	+ Added -fomit-frame-pointer option to Rowley ARM7 demos as work around
+	  to GCC bug at some optimisation levels.
+	+ Altered the way the heap is defined in the LM3S811 Keil demo to prevent
+	  the RAM usage from counting toward the code size limit calculation.
+	+ CO-ROUTINE BUG FIX:  Removed the call to prvIsQueueEmpty from within
+	  xQueueCRReceive as it exited with interrupts enabled.  Thanks Paul Katz.
+	+ Tasks that block on events with a timeout of portMAX_DELAY are now
+	  blocked indefinitely if configINCLUDE_vTaskSuspend is defined.
+	  Previously portMAX_DELAY was just the longest block time possible. This
+	  is still the case if configINCLUDE_vTaskSuspend is not defined.
+	+ Minor changes to some demo application files.
+
+Changes between V4.1.1 and V4.1.2 released October 21, 2006
+
+	+ Added 16bit PIC ports and demos.
+	+ Added STR750 port and demo.
+
+
+Changes between V4.1.0 and V4.1.1 released September 24, 2006
+
+	+ Added the Luminary Micro Stellaris LM3S811 demo application.
+
+Changes between V4.0.5 and V4.1.0 released August 28, 2006
+
+	+ Prior to V4.1.0, under certain documented circumstances, it was possible
+	  for xQueueSend() and xQueueReceive() to return without having completed
+	  and without their block time expiring.  The block time effectively
+	  stated a maximum block time, and the return value of the function needed
+	  to be checked to determine the reason for returning.  This is no longer
+	  the case as the functions will only return once the block time has
+	  expired or they are able to complete their operation.  It is therefore no
+	  longer necessary to wrap calls within loops.
+	+ Changed the critical section handling in the IAR AVR port to correct the
+	  behaviour when used with later compiler versions.
+	+ Added the LPC2138 CrossWorks demo into the zip file.  Previously this was
+	  only available as a separate download.
+	+ Modified the AVR demo applications to demonstrate the use of co-routines.
+
+Changes between V4.0.4 and V4.0.5 released August 13, 2006
+
+	+ Introduced API function xTaskResumeFromISR().  Same functionality as
+	  xTaskResume(), but can be called from within an interrupt service routine.
+	+ Optimised vListInsert() in the case when the wake time is the maximum
+	  tick count value.
+	+ Bug fix:  The 'value' of the event list item is updated when the priority
+	  of a task is changed.  Previously only the priority of the TCB itself was
+	  changed.
+	+ vTaskPrioritySet() and vTaskResume() no longer use the event list item.
+	  This has not been necessary since V4.0.1 when the xMissedYield handling
+	  was added.
+	+ Lowered the PCLK setting on the ARM9 STR9 demo from 96MHz to 48MHz.
+	+ When ending the scheduler - do not try to attempt a context switch when
+	  deleting the current task.
+	+ SAM7X EMAC drivers:  Corrected the Rx frame length mask when obtaining
+	  the length from the rx descriptor.
+
+
+Changes between V4.0.3 and V4.0.4 released June 22, 2006
+
+	+ Added a port and demo application for the STR9 ARM9 based processors from
+	  ST.
+	+ Slight optimisation to the vTaskPrioritySet() function.
+	+ Included the latest uIP version (1.0) in the demo/common/ethernet
+	  directory.
+
+Changes between V4.0.2 and V4.0.3 released June 7, 2006
+
+	+ Added a port and demo application for the Cortex-M3 target using the IAR
+	  development tools.
+	+ The ARM Cortex-m3 Rowley projects have been updated to use V1.6 of the
+	  CrossStudio tools.
+	+ The heap size defined for the lwIP Rowley demo has been reduced so that
+	  the project will link correctly when using the command line GCC tools
+	  also.  The makefile has also been modified to allow debugging.
+	+ The lwIP Rowley demo not includes a 'kernel aware' debug window.
+	+ The uIP Rowley project has been updated to build with V1.6 of CrossWorks.
+	+ The second set of tasks in the blockQ demo were created the wrong way
+	  around (inconsistent to the description in the file).  This has been
+	  corrected.
+
+Changes between V4.0.1 and V4.0.2 released May 28, 2006
+
+	+ Port and demo application added for the Tern Ethernet Engine controller.
+	+ Port and demo application added for MC9S12 using GCC, thanks to
+	  Jefferson "imajeff" Smith.
+	+ The function vTaskList() now suspends the scheduler rather than disabling
+	  interrupts during the creation of the task list.
+	+ Allow a task to delete itself by passing in its own handle.  Previously
+	  this could only be done by passing in NULL.
+	+ Corrected the value passed to the WDG_PeriodValueConfig() library
+	  function in the STR71x demo.
+	+ The tick hook function is now called only within a tick isr.  Previously
+	  it was also called when the tick function was called during the scheduler
+	  unlocking process.
+	+ The EMAC driver in the SAM7X lwIP demo has been made more robust as per
+	  the thread: http://sourceforge.net/forum/message.php?msg_id=3714405
+	+ In the PC ports:  Add function prvSetTickFrequencyDefault() to set the
+	  DOS tick back to its proper value when the scheduler exits.  Thanks
+	  Raynald!
+	+ In the Borland x86 ports there was a mistake in the portFIRST_CONTEXT
+	  macro where the BP register was not popped from the stack correctly.  The
+	  BP value would never get used so this did not cause a problem, but it has
+	  been corrected all the same.
+
+
+Changes between V4.0.0 and V4.0.1 released April 7 2006
+
+	+ Improved the ARM CORTEX M3 ports so they now only have to service
+	  pendSV interrupts.
+	+ Added a Luminary Micro port and demo for use with Rowley CrossWorks.
+	+ Added the xMissedYield handling to tasks.c.
+
+Changes between V3.2.4 and V4.0.0
+
+	Major changes:
+
+	+ Added new RTOS port for Luminary Micros ARM CORTEX M3 microcontrollers.
+	+ Added new co-routine functionality.
+
+	Other kernel changes:
+
+	+ An optional tick hook call is now included in the tick function.
+	+ Introduced the xMiniListItem structure and removed the list pxHead
+	  member in order to reduce RAM usage.
+	+ Added the following definitions to the FreeRTOSConfig.h file included
+	  with every port:
+		configUSE_TICK_HOOK
+		configUSE_CO_ROUTINES
+		configMAX_CO_ROUTINE_PRIORITIES
+	+ The volatile qualification has been changed on the list members to allow
+	  the task.c code to be tidied up a bit.
+	+ The scheduler can now be started even if no tasks have been created!
+	  This is to allow co-routines to run when there are no tasks.
+	+ A task being woken by an event will now preempt the currently running task
+	  even if its priority is only equal to the currently running task.
+
+	Port and demo application changes:
+
+	+ Updated the WinAVR demo to compile with the latest version of WinAVR
+	  with no warnings generated.
+	+ Changed the WinAVR makefile to make chars signed - needed for the
+	  co-routine code if BaseType_t is set to char.
+	+ Added new demo application file crflash.c.  This demonstrates co-routine
+	  functionality including passing data between co-routines.
+	+ Added new demo application file crhook.c.  This demonstrates co-routine
+	  and tick hook functionality including passing data between and ISR and
+	  a co-routine.
+	+ Some NOP's were missing following stmdb{}^ instructions in various ARM7
+	  ports.  These have been added.
+	+ Updated the Open Watcom PC demo project to include the crflash and crhook
+	  demo co-routines as an example of their use.
+	+ Updated the H8S demo to compile with the latest version of GCC.
+	+ Updated the SAM7X EMAC drivers to take into account the hardware errata
+	  regarding lost packets.
+	+ Changed the default MAC address used by some WEB server demos as the
+	  original addresses used was not liked by some routers.
+	+ Modified the SAM7X/IAR startup code slightly to prevent it hanging on
+	  some systems when the code is executed using a j-link debugger.  The
+	  j-link macro file configures the PLL before the code executes so
+	  attempting to configure it again in the startup code was causing a
+	  problem for some user.  Now a check is performed first to see if the
+	  PLL is already set up.
+	+ GCC port now contain all assembler code in a single asm block rather than
+	  individual blocks as before.
+	+ GCC LPC2000 code now explicitly uses R0 rather than letting the assembler
+	  choose the register to use as a temporary register during the context
+	  switch.
+	+ Added portNOP() macro.
+	+ The compare match load value on LPC2000 ports now has 1 added to correct
+	  the value used.
+	+ The minimal stack depth has been increased slightly on the WIZC PIC18
+	  port.
+
+Changes between V3.2.3 and V3.2.4
+
+	+ Modified the GCC ARM7 port layer to allow use with GCC V4.0.0 and above.
+	  Many thanks to Glen Biagioni for the provided update.
+	+ Added a new Microblaze port and demo application.
+	+ Modified the SAM7X EMAC demo to default to use the MII interface rather
+	  than the RMII interface.
+	+ Modified the startup sequence of the SAM7X demo slightly to allow the
+	  EMAC longer to auto negotiate.
+
+Changes between V3.2.2 and V3.2.3
+
+	+ Added MII interface support to the SAM7X EMAC peripheral driver.
+	  Previously versions worked with the RMII interface only.
+	+ Added command line GCC support to the SAM7X lwIP demo.  Previously the
+	  project could only be built using the CrossWorks IDE.  Modifications to
+	  this end include the addition of a standard makefile and linker script to
+	  the download, and some adjustments to the stacks allocated to each task.
+	+ Changed the page returned by the lwIP WEB server demo to display the
+	  task status table rather than the TCP/IP statistics.
+	+ Corrected the capitalisation of some header file includes and makefile
+	  dependencies to facilitate use on Linux host computers.
+	+ The various LPC2000 ports had a mistake in the timer setup where the
+	  prescale value was written to T0_PC instead of T0_PR.  This would have
+	  no effect unless a prescale value was actually required.  This has been
+	  corrected.
+
+Changes between V3.2.1 and V3.2.2 - Released 23 September, 2005
+
+	+ Added an IAR port for the Philips LPC2129
+	+ The Atmel ARM7 IAR demo project files are now saved in the IAR Embedded
+	  Workbench V4.30a format.
+	+ Updated the J-Link macro file included with the SAM7X uIP demo project
+	  to allow the demo board to be reset over the J-Link.
+
+Changes between V3.2.0 and V3.2.1 - Released 1 September, 2005
+
+	+ Added lwIP demo for AT91SAM7X using Rowley tools.
+	+ Added uIP demo for AT91SAM7X using IAR tools.
+	+ Added function xTaskGetCurrentTaskHandle().
+	+ Renamed events.h to mevents.h to prevent it conflicting with the events.h
+	  generated automatically by the HCS12 processor expert utility.  events.h
+	  is only used by the PC demo application.
+	+ Both PIC18 ports now initialise the TBLPTRU to 0 as this is the value
+	  expected by the compiler, and the compilers do not write to this
+	  register.
+	+ The HCS12 banked model demo now creates the 'suicide' tasks immediately
+	  prior to starting the scheduler.  These tasks should be the last tasks to
+	  get started in order for the test to function correctly.
+
+Changes between V3.1.1 and V3.2.0 - Released 29 June, 2005
+
+	V3.2.0 introduces two new MSP430 ports and corrects a minor kernel
+	issues.  Thanks to Ares.qi for his input.
+
+	+ Added two MSP430 ports that use the Rowley CrossWorks development tools.
+	  One port just mirrors the existing GCC port.  The other port was provided
+	  by Milos Prokic.  Thanks!
+	+ V3.2.0 corrects the behavior when vTaskPrioritySet() or vTaskResume()
+	  are called while the scheduler is locked (by a call to
+	  vTaskSuspendAll()).  When this is done the subject task now starts to
+	  execute immediately when the scheduler is unlocked if it has the highest
+	  priority that is ready to run.  Previously there was a possibility that
+	  the task would not run until the next RTOS tick or call to portYIELD().
+	+ Another similar small correction ensures that in the case where more than
+	  one task is blocked on a semaphore or queue, the task with the highest
+	  priority is guaranteed to be unblocked first.
+	+ Added a couple of more test tasks to the PC demo which cover the points
+	  above.
+
+Changes between V3.1.0 and V3.1.1 - Released 21st June, 2005
+
+	This release updates the HCS12 port.  The common kernel code
+	remains unchanged.
+
+	+ Updated the HCS12 port to support banking and introduced a demo
+	  application for the MC9S12DP256.  The new demo application is
+	  located in the Demo/HCS12_CodeWarrior_banked directory.
+	+ The name of the directory containing the MC9S12F32 demo application
+	  has been changed to Demo/HCS12_CodeWarrior_small (as in 'small'
+	  memory model).
+	+ MC9S12F32 demo updated slightly to use the PLL.  The CPU speed for the
+	  demo application is now 24MHz.  Previously it was 8MHz.
+	+ The demo application file Demo/Common/Minimal/death.c has a slight
+	  alteration to prevent it using floating point variables.
+
+
+Changes between V3.0.0 and V3.1.0 - Released 11th June, 2005
+
+	+ Added new ports for ST Microsystems STR71x, and Freescale HCS12
+	  microcontrollers.  Currently the HCS12 port is limited to the small
+	  memory model.  Large memory models will be supported in the next
+	  release.
+	+ PIC18 wizC port updated.  Thanks to Marcel van Lieshout for his
+	  continuing contribution.
+	+ The accuracy of the AVR port timer setup has been improved.  Thanks to
+	  Thomas Krutmann for this contribution.
+	+ Added a new conditional compilation macro configIDLE_SHOULD_YIELD.
+	  See the WEB documentation for details.
+	+ Updated the CrossWorks uIP demo to build with V1.4 of CrossWorks.
+	+ Slight modification to the SAM7 release build configuration to correct
+	  an include path definition.
+	+ Updated the MPLAB PIC18 documentation to provide extra details on linker
+	  file configuration.
+
+Changes between V3.0.0 and V2.6.1 - Released 23rd April, 2005
+
+	V3.0.0 includes many enhancements, so this history list is broken into
+	subsections as follows:
+
+		API changes
+		New ports
+		Directory name changes
+		Kernel and miscellaneous changes changes
+
+	- API changes
+
+		+ Each port now defines BaseType_t as the data type that is most
+		  efficient for that architecture.  The type BaseType_t is used
+		  extensively in API calls necessitating the following changes to the
+		  FreeRTOS API function prototypes.
+
+		  See the "New for V3.0.0" section of the FreeRTOS online
+		  documentation for full details of API changes.
+
+	- New ports
+
+		+ The AT91FR40008 ARM7 port contributed by John Feller is now included
+		  in the download (thanks John!).
+		+ The PIC18 port for the wizC/fedC compiler contributed by Marcel van
+		  Lieshout is now included in the download (thanks Marcel!).
+		+ The IAR port for the AVR microcontroller has been upgraded to V3.0.0
+		  and is now a supported port.
+
+	- Directory name changes
+
+		For consistency, and to allow integration of the new ports, the
+		following directory names have been changed.
+
+		+ The source/portable/GCC/ARM7 directory has been renamed
+		  source/portable/GCC/ARM7_LPC2000 so it is compatible with the naming
+		  of other GCC ARM7 ports.
+		+ The Demo/PIC directory has been renamed Demo/PIC18_MPLAB to
+		  accommodate the wizC/fedC PIC port.
+		+ The demo applications for the two AVR ports no longer share the same
+		  directory.  The WinAVR demo is in the Demo/AVR_ATMega323_WinAVR
+		  directory and the IAR port in the Demo/AVR_ATMega323_IAR directory.
+
+
+	- Kernel and miscellaneous changes changes
+
+		  See the "New for V3.0.0" section of the FreeRTOS online
+		  documentation for more information.
+
+		+ Previously 'portmacro.h' contained some user editable definitions
+		  relating to the user application, and some fixed definitions relating
+		  specifically to the port being used.  The application specific
+		  definitions have been removed from 'portmacro.h' and placed inside a
+		  new header file called 'FreeRTOSConfig.h'.  'portmacro.h' should now
+		  never be modified by the user.  A 'FreeRTOSConfig.h' is now included
+		  in each of FreeRTOS/Demo subdirectories - as it's settings relate to
+		  the demo application rather than being specific to the port.
+		+ Introduced configUSE_IDLE_HOOK in idle task.
+		+ The idle task will yield when another idle priority task is ready to
+		  run. Previously the idle task would run to the end of its time slice
+		  regardless.
+		+ The idle task is now created when the scheduler is started.  This
+		  requires less stack than the previous scheme where it was created upon
+		  creation of the first application task.
+		+ The function usPortCheckFreeStackSpace() has been renamed
+		  usTaskCheckFreeStackSpace() and moved from the portable layer to
+		  tasks.c.
+		+ Corrected spelling of portMINMAL_STACK_SIZE to portMINIMAL_STACK_SIZE.
+		+ The portheap.c file included with the AVR port has been deleted.  The
+		  AVR demo now uses the standard heap1 sample memory allocator.
+		+ The GCC AVR port is now build using the standard make utility.  The
+		  batch files used previously have been deleted.  This means a recent
+		  version of WinAVR is required in order to create a binary suitable for
+		  source level debugging.
+		+ vTaskStartScheduler() no longer takes the configUSE_PREEMPTION
+		  constant as a parameter.  Instead the constant is used directly within
+		  tasks.c  and no parameter is required.
+		+ The header file 'FreeRTOS.h' has been created and is used to include
+		  'projdefs.h', 'FreeRTOSConfig.h' and 'portable.h' in the necessary
+		  order.  FreeRTOS.h can now be included in place of these other
+		  headers.
+		+ The header file 'errors.h' has been deleted.  The definitions it
+		  contained are now located within 'projdefs.h'.
+		+ pvPortMalloc() now takes a size_t parameter as per the ANSI malloc().
+		  Previously an unsigned short was used.
+		+ When resuming the scheduler a yield is performed if either a tick has
+		  been missed, or a task is moved from the pending ready list into a
+		  ready list.  Previously a yield was not performed on this second
+		  condition.
+		+ In heap1.c an overflow check has been added to ensure the next free
+		  byte variable does not wrap around.
+		+ Introduced the portTASK_FUNCTION() and portTASK_FUNCTION_PROTO()
+		  macros.
+		+ The MPLAB PIC port now saved the TABLAT register in interrupt service
+		  routines.
+
+Changes between V2.6.0 and V2.6.1 - Released Feb 22, 2005
+
+	This version adds support for the H8 processor.
+
+	Other changes:
+
+	+ tskMAX_TASK_NAME_LEN removed from the task.h header and added to each
+	  individual portmacro.h file as portMAX_TASK_NAME_LEN.  This allows RAM
+	  limited ports to allocate fewer characters to the task name.
+	+ AVR port - Replaced the inb() and outb() functions with direct memory
+	  access.  This allows the port to be built with the 20050414 build of
+	  WinAVR.
+	+ GCC LPC2106 port - removed the 'static' from the definition of
+	  vNonPreemptiveTick() to allow the demo to link when using the cooperative
+	  scheduler.
+	+ GCC LPC2106 port - Corrected the optimisation options in the batch files
+	  ROM_THUMB.bat, RAM_THUMB.bat, ROM_ARM.bat and RAM_ARM.bat.  The lower case
+	  -o is replaced by an uppercase -O.
+	+ Tasks.c - The strcpy call has been removed when copying across the task
+	  name into the TCB.
+	+ Updated the trace visualisation to always be 4 byte aligned so it can be
+	  used on ARM architectures.
+	+ There are now two tracecon executables (that convert the trace file binary
+	  into an ASCII file).  One for big endian targets and one for little endian
+	  targets.
+	+ Added ucTasksDeleted variable to prevent vTaskSuspendAll() being called
+	  too often in the idle task.
+	+ SAM7 USB driver - Replaced the duplicated RX_DATA_BK0 in the interrupt
+	  mask with the RX_DATA_BK1.
+
+
+Changes between V2.5.5 and V2.6.0 - Released January 16, 2005
+
+	+ Added the API function vTaskDelayUntil().  The demo app file
+	  Demo/Common/Minimal/flash.c has been updated to demonstrate its use.
+	+ Added INCLUDE_vTaskDelay conditional compilation.
+	+ Changed the name of the Demo/ARM7_AtmelSAM7S64_IAR directory to
+	  Demo/ARM7_AT91SAM7S64_IAR for consistency.
+	+ Modified the AT91SAM7S USB driver to allow descriptors that have
+	  a length that is an exact multiple of the FIFO to be transmitted.
+
+Changes between V2.5.4 and V2.5.5 - Released January 3, 2005
+
+	This version adds support for the Atmel SAM7 ARM7 microcontrollers
+	along with the IAR development tools.
+
+	Other changes:
+
+	+ Renamed the Demo/ARM7 directory to Demo/ARM7_LPC2106_GCC.
+	+ Renamed the Demo/ARM7_Keil directory to Demo/ARM7_LPC2129_Keil.
+	+ Modified the Philips ARM7 serial interrupt service routines to only
+	  process one interrupt per call.  This seems to enable the ISR to
+	  operate more quickly.
+	+ Removed the 'far' keyword from the Open Watcom portable layer source
+	  files.  This allows their use with V1.3 of Open Watcom.
+	+ Minor modifications to the SDCC build files to allow their use under
+	  Linux.  Thanks to Frieder Ferlemann for this contribution.
+	+ Small change to sTaskCreate() to allow a context switch even when
+	  pxCreatedTask is NULL.  Thanks to Kamil for this contribution.
+	+ inline keyword removed from vTaskSwitchContext() and VTaskIncrementTick()
+	  definitions.
+
+Changes between V2.5.3 and V2.5.4 - Released Dec 1, 2004
+
+	This is an important maintenance release.
+
+	The function cTaskResumeAll() has been modified so it can be used safely
+	prior to the kernel being initialised.  This was an issue as
+	cTaskResumeAll() is called from pvPortMalloc().  Thanks to Daniel Braun
+	for highlighting this issue.
+
+Changes between V2.5.2 and V2.5.3 - Released Nov 2, 2004
+
+	The critical section handling functions have been changed for the GCC ARM7
+	port.   Some optimisation levels use the stack differently to others.  This
+	means the interrupt flags cannot always be stored on the stack and are
+	instead now stored in a variable, which is then saved as part of the
+	tasks context.  This allows the GCC ARM7 port to be used at all
+	optimisation levels - including -Os.
+
+	Other minor changes:
+
+	+ MSP430 definition of usCriticalNesting now uses the volatile qualifier.
+	  This is probably not required but added just in case.
+
+Changes between V2.5.1 and V2.5.2 - Released Oct 26, 2004
+
+	+ Added the Keil ARM7 port.
+	+ Slight modification to comtest.c to make the delay periods more random.
+	  This creates a better test condition.
+
+Changes between V2.5.0 and V2.5.1 - Released Oct 9, 2004
+
+	+ Added the MSP430 port.
+	+ Extra comments added to the GCC ARM7 port.c and portISR.c files.
+	+ The memory pool allocated within heap_1.c has been placed within a
+	  structure to ensure correct memory alignment on 32bit systems.
+	+ Within the GCC ARM7 serial drivers an extra check is made to ensure
+	  the post to the queue was successful if then attempting immediately
+	  retrieve the posted character.
+	+ Changed the name of the constant portTICKS_PER_MS to portTICK_PERIOD_MS
+	  as the old name was misleading.
+
+
+Changes between V2.4.2 and V2.5.0 - Released Aug 12, 2004
+
+	The RTOS source code download now includes three separate memory allocation
+	schemes - so you can choose the most appropriate for your application.
+	These are found in the Source/Portable/MemMang directory.  The demo
+	application projects have also been updated to demonstrate the new schemes.
+	See the "Memory Management" page of the API documentation for more details.
+
+	+ Added heap_1.c, heap_2.c and heap_3.c in the Source/Portable/MemMang
+	  directory.
+	+ Replaced the portheap.c files for each demo application with one of the
+	  new memory allocation files.
+	+ Updated the portmacro.h file for each demo application to include the
+	  constants required for the new memory allocators: portTOTAL_HEAP_SIZE and
+	  portBYTE_ALIGNMENT.
+	+ Added a new test to the ARM7 demo application that tests the operation
+	  of the heap_2 memory allocator.
+
+
+Changes between V2.4.1 and V2.4.2 - Released July 14, 2004
+
+	+ The ARM7 port now supports THUMB mode.
+	+ Modification to the ARM7 demo application serial port driver.
+
+Changes between V2.4.0 and V2.4.1 - Released July 2, 2004
+
+	+ Rationalised the ARM7 port version of portEXIT_CRITICAL() -
+	  improvements provided by Bill Knight.
+	+ Made demo serial driver more complete and robust.
+
+
+Changes between V2.4.0 and V2.3.1 - Released June 30, 2004
+
+	+ Added the first ARM7 port - thanks to Bill Knight for the assistance
+	  provided.
+	+ Added extra files to the Demo/Common/Minimal directory.  These are
+	  equivalent to their Demo/Common/Full counterparts but with the
+	  calls to the functions defined in print.c removed.
+	+ Added TABLAT to the list of registers saved as part of a PIC18 context.
+
+Changes between V2.3.0 and V2.3.1 - Released June 25, 2004
+
+	+ Changed the way the vector table is defined to be more portable.
+	+ Corrected the definitions of SPH and SPL in portmacro.s90.
+	  The previous definitions prevented V2.3.0 operating if the iom323.h
+	  header file was included in portmacro.s90.
+
+Changes between V2.2.0 and V2.3.0 - Released June 19, 2004
+
+	+ Added an AVR port that uses the IAR compiler.
+	+ Explicit use of 'signed' qualifier on plain char types.
+	+ Modified the Open Watcom project files to use 'signed' as the
+	  default char type.
+	+ Changed odd calculation of initial pxTopOfStack value when
+	  portSTACK_GROWTH < 0.
+	+ Added inline qualifier to context switch functions within task.c.
+	  Ports that do not support the (non ANSI) inline keyword have the
+	  inline #define'd away in  their respective portmacro.h files.
+
+Changes between V2.1.1 and V2.2.0 - Released May 18, 2004
+
+	+ Added Cygnal 8051 port.
+	+ PCLATU and PCLATH are now saved as part of the PIC18 context.  This
+	  allows function pointers to be used within tasks.  Thanks to Javier
+	  Espeche for the enhancement.
+	+ Minor changes to demo application files to reduce stack usage.
+	+ Minor changes to prevent compiler warnings when compiling the new port.
+
+Changes between V2.1.0 and V2.1.1 - Released March 12, 2004
+
+	+ Bug fix - pxCurrentTCB is now initialised before the call to
+	  prvInitialiseTaskLists().  Previously pxCurrentTCB could be accessed
+	  while null during the initialisation sequence.  Thanks to Giuseppe
+	  Franco for the correction.
+
+Changes between V2.0.0 and V2.1.0 - Released Feb 29, 2004
+
+	V2.1.0 has significant reworks that greatly reduce the amount of time
+	the kernel has interrupts disabled.  The first section of modifications
+	listed here must be taken into account by users.  The second section
+	are related to the kernel implementation and as such are transparent.
+
+	Section1 :
+
+	+ The typedef TickType_t has been introduced.  All delay times should
+	  now use a variable of type TickType_t in place of the unsigned long's
+	  used previously.  API function prototypes have been updated
+	  appropriately.
+	+ The configuration macro USE_16_BIT_TICKS has been introduced.  If set
+	  to 1 TickType_t is defined as an unsigned short.  If set to 0
+	  TickType_t is defined as an unsigned long.  See the configuration
+	  section of the API documentation for more details.
+	+ The configuration macro INCLUDE_vTaskSuspendAll is now obsolete.
+	+ vTaskResumeAll() has been renamed cTaskResumeAll() as it now returns a
+	  value (see the API documentation).
+	+ ulTaskGetTickCount() has been renamed xTaskGetTickCount() as the type
+	  it returns now depends on the USE_16_BIT_TICKS definition.
+	+ cQueueReceive() must now >never< be used from within an ISR.  Use the new
+	  cQueueReceiveFromISR() function instead.
+
+	Section 2:
+
+	+ A mechanism has been introduced that allows a queue to be accessed by
+	  a task and ISR simultaneously.
+	+ A "pending ready" queue has been introduced that enables interrupts to
+	  be processed when the scheduler is suspended.
+	+ The list implementation has been improved to provide faster item
+	  removal.
+	+ The scheduler now makes use of the scheduler suspend mechanism in places
+	  where previously interrupts were disabled.
+
+Changes between V1.2.6 and V2.0.0 - Released Jan 31, 2004
+
+	+ Introduced new API functions:
+		vTaskPriorityGet ()
+		vTaskPrioritySet ()
+		vTaskSuspend ()
+		vTaskResume ()
+		vTaskSuspendAll ()
+		vTaskResumeAll ()
+	+ Added conditional compilation options that allow the components of the
+	  kernel that are unused by an application to be excluded from the build.
+	  See the Configuration section on the WEB site for more information (on
+	  the API pages).  The macros have been added to each portmacro.h file (
+	  sometimes called prtmacro.h).
+	+ Rearranged tasks.c.
+	+ Added demo application file dynamic.c.
+	+ Updated the PC demo application to make use of dynamic.c.
+	+ Updated the documentation contained in the kernel header files.
+	+ Creating a task now causes a context switch if the task being created
+	  has a higher priority than the calling task - assuming the kernel is
+	  running.
+	+ vTaskDelete() now only causes a context switch if the calling task is
+	  the task being deleted.
+
+Changes between V1.2.5 and V1.2.6 - Released December 31, 2003
+
+	Barring the change to the interrupt vector (PIC port) these are minor
+	enhancements.
+
+	+ The interrupt vector used for the PIC master ISR has been changed from
+	  0x18 to 0x08 - where it should have always been.  The incorrect address
+	  still works but probably executes a number of NOP's before getting to the
+	  ISR.
+	+ Changed the baud rate used by the AVR demo application to 38400.  This
+	  has an error percentage of less than one percent with an 8MHz clock.
+	+ Raised the priority of the Rx task in demo\full\comtest.c.  This only
+	  affects the Flashlite and PC ports.  This was done to prevent the Rx
+	  buffer becoming full.
+	+ Reverted the Flashlite COM port driver back so it does not use the DMA.
+	  The DMA appears to miss characters under stress.  The Borland Flashlite
+	  port was also calculating a register value incorrectly resulting in the
+	  wrong DMA source address being used.  The same code worked fine when
+	  compiling with Open Watcom.  Other minor enhancements were made to the
+	  interrupt handling.
+	+ Modified the PIC serial Rx ISR to check for and clear overrun errors.
+	  Overrun errors seem to prevent any further characters being received.
+	+ The PIC demo projects now have some optimisation switched on.
+
+
+Changes between V1.2.4 and V1.2.5
+
+	Small fix made to the PIC specific port.c file described below.
+
+	+ Introduced portGLOBAL_INTERRUPT_FLAG definition to test the global
+	  interrupt flag setting.  Using the two bits defined within
+	  portINITAL_INTERRUPT_STATE was causing the w register to get clobbered
+	  before the test was performed.
+
+Changes between V1.2.3 and V1.2.4
+
+	V1.2.4 contains a release version of the PIC18 port.
+	An optional exception has been included with the GPL.  See the licensing
+	section of www.FreeRTOS.org for details.
+
+	+ The function xPortInitMinimal() has been renamed to
+	  xSerialPortInitMinimal() and the function xPortInit() has been renamed
+	  to xSerialPortInit().
+	+ The function sSerialPutChar() has been renamed cSerialPutChar() and
+	  the function return type chaned to portCHAR.
+	+ The integer and flop tasks now include calls to tskYIELD(), allowing
+	  them to be used with the cooperative scheduler.
+	+ All the demo applications now use the integer and comtest tasks when the
+ 	  cooperative scheduler is being used.  Previously they were only used with
+	  the preemptive scheduler.
+	+ Minor changes made to operation of minimal versions of comtest.c and
+	  integer.c.
+	+ The ATMega port definition of portCPU_CLOSK_HZ definition changed to
+	  8MHz base 10, previously it base 16.
+
+
+
+Changes between V1.2.2a and V1.2.3
+
+	The only change of any significance is to the license, which has changed
+	from the Open Software License to the GNU GPL.
+
+	The zip file also contains a pre-release version of the PIC18 port.  This
+	has not yet completed testing and as such does not constitute part of the
+	V1.2.3 release.  It is still however covered by the GNU GPL.
+
+	There are minor source code changes to accommodate the PIC C compiler.
+	These mainly involve more explicit casting.
+
+	+ sTaskCreate() has been modified slightly to make use of the
+	  portSTACK_GROWTH macro.  This is required for the PIC port where the
+	  stack grows in the opposite direction to the other existing ports.
+	+ prvCheckTasksWaitingTermination() has been modified slightly to bring
+	  the decrementing of usCurrentNumberOfTasks within the critical section,
+	  where it should have been since the creation of an eight bit port.
+
+Changes between V1.2.2 and V1.2.2a
+
+	The makefile and buildcoff.bat files included with the AVR demo application
+	have been modified for use with the September 2003 build of WinAVR.  No
+	source files have changed.
+
+Changes between V1.2.1 and V1.2.2
+
+	There are only minor changes here to allow the PC and Flashlite 186 ports
+	to use the Borland V4.52 compiler, as supplied with the Flashlite 186
+	development kit.
+
+	+ Introduced a BCC directory under source\portable.  This contains all the
+	  files specific to the Borland compiler port.
+	+ Corrected the macro naming of portMS_PER_TICK to portTICKS_PER_MS.
+	+ Modified comtest.c to increase the rate at which the string is
+	  transmitted and received on the serial port.  The Flashlite 186 demo
+	  app baud rate has also been increased.
+	+ The values of the constants used in both integer.c files have been
+          increased to force the Borland compiler to use 32 bit values.  The
+          Borland optimiser placed the previous values in 16 bit registers, and in
+          So doing invalidated the test.
+
+Changes between V1.2.0 and V1.2.1
+
+	This version includes some minor changes to the list implementation aimed
+	at improving the context switch time - with is now approximately 10% faster.
+	Changes include the removal of some null pointer assignment checks.  These
+	were redundant where the scheduler uses the list functions, but means any
+	user application choosing to use the same list functions must now check
+	that no NULL pointers are passed as a parameter.
+
+	The Flashlite 186 serial port driver has also been modified to use a DMA
+	channel for transmissions.  The serial driver is fully functional but still
+	under development.  Flashlite users may prefer to use V1.2.0 for now.
+
+	Details:
+
+	+ Changed the baud rate for the ATMega323 serial test from 19200 to 57600.
+	+ Use vSerialPutString() instead of single character puts in
+	  Demo\Full\Comtest.c.  This allows the use of the flashlite DMA serial
+	  driver.  Also the check variable only stops incrementing after two
+	  consecutive failures.
+	+ semtest.c creates four tasks, two of which operate at the idle priority.
+	  The tasks that operate at the idle priority now use a lower expected
+	  count than those running at a higher priority.  This prevents the low
+	  priority tasks from signalling an error because they have not been
+	  scheduled enough time for each of them to count the shared variable to
+	  the higher original value.
+	+ The flashlite 186 serial driver now uses a DMA channel for transmissions.
+	+ Removed the volatile modifier from the list function parameters.  This was
+	  only ever included to prevent compiler warnings.  Now warnings are
+	  removed by casting parameters where the calls are made.
+	+ prvListGetOwnerOfNextEntry() and prvListGetOwnerOfHeadEntry() have been
+	  removed from list.c and added as macros in list.h.
+	+ usNumberOfItems has been added to the list structure.  This removes the
+	  need for a pointer comparison when checking if a list is empty, and so
+	  is slightly faster.
+	+ Removed the NULL check in vListRemove().  This makes the call faster but
+	  necessitates any application code utilising the list implementation to
+	  ensure NULL pointers are not passed.
+	+ Renamed portTICKS_PER_MS definition to portMS_PER_TICK (milli seconds
+	  per tick).  This is what it always should have been.
+
+Changes between V1.01 and V1.2.0
+
+	The majority of these changes were made to accommodate the 8bit AVR port.
+	The scheduler workings have not changed, but some of the data types used
+	have been made more friendly to an eight bit environment.
+
+	Details:
+
+	+ Changed the version numbering format.
+	+ Added AVR port.
+	+ Split the directory demo\common into demo\common\minimal and
+	  demo\common\full.  The files in the full directory are for systems with
+	  a display (currently PC and Flashlite 186 demo's).  The files in the
+	  minimal directory are for systems with limited RAM and no display
+	  (currently MegaAVR).
+	+ Minor changes to demo application function prototypes to make more use
+	  of 8bit data types.
+	+ Within the scheduler itself the following functions have slightly
+	  modified declarations to make use of 8bit data types where possible:
+		xQueueCreate(),
+		sQueueReceive(),
+		sQUeueReceive(),
+		usQueueMessageWaiting(),
+		sQueueSendFromISR(),
+		sSemaphoreTake(),
+		sSemaphoreGive(),
+		sSemaphoreGiveFromISR(),
+		sTaskCreate(),
+		sTaskMoveFromEventList().
+
+	  Where the return type has changed the function name has also changed in
+	  accordance with the naming convention.  For example
+	  usQueueMessageWaiting() has become ucQueueMessageWaiting().
+	+ The definition tskMAX_PRIORITIES has been moved from task.h to
+	  portmacro.h and renamed portMAX_PRIORITIES.  This allows different
+	  ports to allocate a different maximum number of priorities.
+	+ By default the trace facility is off, previously USE_TRACE_FACILITY
+	  was defined.
+	+ comtest.c now uses a psuedo random delay between sends.  This allows for
+	  better testing as the interrupts do not arrive at regular intervals.
+	+ Minor change to the Flashlite serial port driver.  The driver is written
+	  to demonstrate the scheduler and is not written to be efficient.
+
+
+
+Changes between V1.00 and V1.01
+
+	These changes improve the ports.  The scheduler itself has not changed.
+
+	Improved context switch mechanism used when performing a context
+	switch from an ISR (both the tick ISR and the serial comms ISR's within
+	the demo application).  The new mechanism is faster and uses less stack.
+
+	The assembler file portasm.asm has been replaced by a header file
+	portasm.h.  This includes a few assembler macro definitions.
+
+	All saving and restoring of registers onto/off of the stack is now handled
+	by the compiler.  This means the initial stack setup for a task has to
+	mimic the stack used by the compiler, which is different for debug and
+	release builds.
+
+	Slightly changed the operation of the demo application, details below.
+
+	Details:
+
+	+ portSWITCH_CONTEXT() replaced by vPortFirstContext().
+	+ pxPortInitialiseStack() modified to replicate the stack used by the
+	  compiler.
+	+ portasm.asm file removed.
+	+ portasm.h introduced.  This contains macro definitions for
+	  portSWITCH_CONTEXT() and portFIRST_CONTEXT().
+	+ Context switch from ISR now uses the compiler generated interrupt
+	  mechanism.  This is done simply by calling portSWITCH_CONTEXT and leaving
+	  the save/restore to compiler generated code.
+	+ Calls to taskYIELD() during ISR's have been replaced by calling the
+	  simpler and faster portSWITCH_CONTEXT().
+	+ The Flashlite 186 port now uses 186 instruction set (used to use 80x86
+	  instructions only).
+	+ The blocking queue tasks within the demo application did not operate
+	  quite as described.  This has been corrected.
+	+ The priority of the comtest Rx task within the demo application has been
+	  lowered.  Received characters are now processed (read from the queue) at
+	  the idle priority, allowing low priority tasks to run evenly at times of
+	  a high communications overhead.
+	+ Prevent the call to kbhit() in main.c for debug builds as the debugger
+	  seems to have problems stepping over the call.  This if for the PC port
+	  only.
+
+
+

--- a/src/FreeRTOS/Source/LICENSE
+++ b/src/FreeRTOS/Source/LICENSE
@@ -1,23 +1,4 @@
-The FreeRTOS kernel is released under the MIT open source license, the text of
-which is provided below.
-
-This license covers the FreeRTOS kernel source files, which are located in the
-/FreeRTOS/Source directory of the official FreeRTOS kernel download.  It also
-covers most of the source files in the demo application projects, which are
-located in the /FreeRTOS/Demo directory of the official FreeRTOS download.  The
-demo projects may also include third party software that is not part of FreeRTOS
-and is licensed separately to FreeRTOS.  Examples of third party software
-includes header files provided by chip or tools vendors, linker scripts,
-peripheral drivers, etc.  All the software in subdirectories of the /FreeRTOS
-directory is either open source or distributed with permission, and is free for
-use.  For the avoidance of doubt, refer to the comments at the top of each
-source file.
-
-
-License text:
--------------
-
-Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to

--- a/src/FreeRTOS/Source/README.md
+++ b/src/FreeRTOS/Source/README.md
@@ -1,0 +1,31 @@
+## Getting started
+This repository contains FreeRTOS kernel source/header files and kernel ports only. This repository is referenced as a submodule in [FreeRTOS/FreeRTOS](https://github.com/FreeRTOS/FreeRTOS) repository, which contains pre-configured demo application projects under ```FreeRTOS/Demo``` directory. 
+
+The easiest way to use FreeRTOS is to start with one of the pre-configured demo application projects.  That way you will have the correct FreeRTOS source files included, and the correct include paths configured.  Once a demo application is building and executing you can remove the demo application files, and start to add in your own application source files.  See the [FreeRTOS Kernel Quick Start Guide](https://www.freertos.org/FreeRTOS-quick-start-guide.html) for detailed instructions and other useful links.
+
+Additionally, for FreeRTOS kernel feature information refer to the [Developer Documentation](https://www.freertos.org/features.html), and [API Reference](https://www.freertos.org/a00106.html).
+
+### Getting help
+If you have any questions or need assistance troubleshooting your FreeRTOS project, we have an active community that can help on the [FreeRTOS Community Support Forum](https://forums.freertos.org).
+
+## Cloning this repository
+
+To clone using HTTPS:
+```
+git clone https://github.com/FreeRTOS/FreeRTOS-Kernel.git
+```
+Using SSH:
+```
+git clone git@github.com:FreeRTOS/FreeRTOS-Kernel.git
+```
+
+## Repository structure
+- The root of this repository contains the three files that are common to 
+every port - list.c, queue.c and tasks.c.  The kernel is contained within these 
+three files.  croutine.c implements the optional co-routine functionality - which
+is normally only used on very memory limited systems.
+
+- The ```./portable``` directory contains the files that are specific to a particular microcontroller and/or compiler. 
+See the readme file in the ```./portable``` directory for more information.
+
+- The ```./include``` directory contains the real time kernel header files.

--- a/src/FreeRTOS/Source/event_groups.c
+++ b/src/FreeRTOS/Source/event_groups.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/FreeRTOS/Source/include/FreeRTOS.h
+++ b/src/FreeRTOS/Source/include/FreeRTOS.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -241,8 +241,24 @@ extern "C" {
 	#define configASSERT_DEFINED 1
 #endif
 
+/* configPRECONDITION should be defined as configASSERT.
+The CBMC proofs need a way to track assumptions and assertions.
+A configPRECONDITION statement should express an implicit invariant or
+assumption made.  A configASSERT statement should express an invariant that must
+hold explicit before calling the code. */
+#ifndef configPRECONDITION
+	#define configPRECONDITION( X ) configASSERT(X)
+	#define configPRECONDITION_DEFINED 0
+#else
+	#define configPRECONDITION_DEFINED 1
+#endif
+
 #ifndef portMEMORY_BARRIER
 	#define portMEMORY_BARRIER()
+#endif
+
+#ifndef portSOFTWARE_BARRIER
+	#define portSOFTWARE_BARRIER()
 #endif
 
 /* The timers module relies on xTaskGetSchedulerState(). */
@@ -937,6 +953,7 @@ V8 if desired. */
 	#define pcTimerGetTimerName pcTimerGetName
 	#define pcQueueGetQueueName pcQueueGetName
 	#define vTaskGetTaskInfo vTaskGetInfo
+	#define xTaskGetIdleRunTimeCounter ulTaskGetIdleRunTimeCounter
 
 	/* Backward compatibility within the scheduler code only - these definitions
 	are not really required but are included for completeness. */

--- a/src/FreeRTOS/Source/include/StackMacros.h
+++ b/src/FreeRTOS/Source/include/StackMacros.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/FreeRTOS/Source/include/atomic.h
+++ b/src/FreeRTOS/Source/include/atomic.h
@@ -1,0 +1,414 @@
+/*
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * @file atomic.h
+ * @brief FreeRTOS atomic operation support.
+ *
+ * This file implements atomic functions by disabling interrupts globally.
+ * Implementations with architecture specific atomic instructions can be
+ * provided under each compiler directory.
+ */
+
+#ifndef ATOMIC_H
+#define ATOMIC_H
+
+#ifndef INC_FREERTOS_H
+	#error "include FreeRTOS.h must appear in source files before include atomic.h"
+#endif
+
+/* Standard includes. */
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Port specific definitions -- entering/exiting critical section.
+ * Refer template -- ./lib/FreeRTOS/portable/Compiler/Arch/portmacro.h
+ *
+ * Every call to ATOMIC_EXIT_CRITICAL() must be closely paired with
+ * ATOMIC_ENTER_CRITICAL().
+ *
+ */
+#if defined( portSET_INTERRUPT_MASK_FROM_ISR )
+
+	/* Nested interrupt scheme is supported in this port. */
+	#define ATOMIC_ENTER_CRITICAL()	 \
+		UBaseType_t uxCriticalSectionType = portSET_INTERRUPT_MASK_FROM_ISR()
+
+	#define ATOMIC_EXIT_CRITICAL()	  \
+		portCLEAR_INTERRUPT_MASK_FROM_ISR( uxCriticalSectionType )
+
+#else
+
+	/* Nested interrupt scheme is NOT supported in this port. */
+	#define ATOMIC_ENTER_CRITICAL()	 portENTER_CRITICAL()
+	#define ATOMIC_EXIT_CRITICAL()	  portEXIT_CRITICAL()
+
+#endif /* portSET_INTERRUPT_MASK_FROM_ISR() */
+
+/*
+ * Port specific definition -- "always inline".
+ * Inline is compiler specific, and may not always get inlined depending on your
+ * optimization level.  Also, inline is considered as performance optimization
+ * for atomic.  Thus, if portFORCE_INLINE is not provided by portmacro.h,
+ * instead of resulting error, simply define it away.
+ */
+#ifndef portFORCE_INLINE
+	#define portFORCE_INLINE
+#endif
+
+#define ATOMIC_COMPARE_AND_SWAP_SUCCESS	 0x1U		/**< Compare and swap succeeded, swapped. */
+#define ATOMIC_COMPARE_AND_SWAP_FAILURE	 0x0U		/**< Compare and swap failed, did not swap. */
+
+/*----------------------------- Swap && CAS ------------------------------*/
+
+/**
+ * Atomic compare-and-swap
+ *
+ * @brief Performs an atomic compare-and-swap operation on the specified values.
+ *
+ * @param[in, out] pulDestination  Pointer to memory location from where value is
+ *                               to be loaded and checked.
+ * @param[in] ulExchange         If condition meets, write this value to memory.
+ * @param[in] ulComparand        Swap condition.
+ *
+ * @return Unsigned integer of value 1 or 0. 1 for swapped, 0 for not swapped.
+ *
+ * @note This function only swaps *pulDestination with ulExchange, if previous
+ *       *pulDestination value equals ulComparand.
+ */
+static portFORCE_INLINE uint32_t Atomic_CompareAndSwap_u32( uint32_t volatile * pulDestination,
+															uint32_t ulExchange,
+															uint32_t ulComparand )
+{
+uint32_t ulReturnValue;
+
+	ATOMIC_ENTER_CRITICAL();
+	{
+		if( *pulDestination == ulComparand )
+		{
+			*pulDestination = ulExchange;
+			ulReturnValue = ATOMIC_COMPARE_AND_SWAP_SUCCESS;
+		}
+		else
+		{
+			ulReturnValue = ATOMIC_COMPARE_AND_SWAP_FAILURE;
+		}
+	}
+	ATOMIC_EXIT_CRITICAL();
+
+	return ulReturnValue;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * Atomic swap (pointers)
+ *
+ * @brief Atomically sets the address pointed to by *ppvDestination to the value
+ *        of *pvExchange.
+ *
+ * @param[in, out] ppvDestination  Pointer to memory location from where a pointer
+ *                                 value is to be loaded and written back to.
+ * @param[in] pvExchange           Pointer value to be written to *ppvDestination.
+ *
+ * @return The initial value of *ppvDestination.
+ */
+static portFORCE_INLINE void * Atomic_SwapPointers_p32( void * volatile * ppvDestination,
+														void * pvExchange )
+{
+void * pReturnValue;
+
+	ATOMIC_ENTER_CRITICAL();
+	{
+		pReturnValue = *ppvDestination;
+		*ppvDestination = pvExchange;
+	}
+	ATOMIC_EXIT_CRITICAL();
+
+	return pReturnValue;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * Atomic compare-and-swap (pointers)
+ *
+ * @brief Performs an atomic compare-and-swap operation on the specified pointer
+ *        values.
+ *
+ * @param[in, out] ppvDestination  Pointer to memory location from where a pointer
+ *                                 value is to be loaded and checked.
+ * @param[in] pvExchange           If condition meets, write this value to memory.
+ * @param[in] pvComparand          Swap condition.
+ *
+ * @return Unsigned integer of value 1 or 0. 1 for swapped, 0 for not swapped.
+ *
+ * @note This function only swaps *ppvDestination with pvExchange, if previous
+ *       *ppvDestination value equals pvComparand.
+ */
+static portFORCE_INLINE uint32_t Atomic_CompareAndSwapPointers_p32( void * volatile * ppvDestination,
+																	void * pvExchange,
+																	void * pvComparand )
+{
+uint32_t ulReturnValue = ATOMIC_COMPARE_AND_SWAP_FAILURE;
+
+	ATOMIC_ENTER_CRITICAL();
+	{
+		if( *ppvDestination == pvComparand )
+		{
+			*ppvDestination = pvExchange;
+			ulReturnValue = ATOMIC_COMPARE_AND_SWAP_SUCCESS;
+		}
+	}
+	ATOMIC_EXIT_CRITICAL();
+
+	return ulReturnValue;
+}
+
+
+/*----------------------------- Arithmetic ------------------------------*/
+
+/**
+ * Atomic add
+ *
+ * @brief Atomically adds count to the value of the specified pointer points to.
+ *
+ * @param[in,out] pulAddend  Pointer to memory location from where value is to be
+ *                         loaded and written back to.
+ * @param[in] ulCount      Value to be added to *pulAddend.
+ *
+ * @return previous *pulAddend value.
+ */
+static portFORCE_INLINE uint32_t Atomic_Add_u32( uint32_t volatile * pulAddend,
+												 uint32_t ulCount )
+{
+	uint32_t ulCurrent;
+
+	ATOMIC_ENTER_CRITICAL();
+	{
+		ulCurrent = *pulAddend;
+		*pulAddend += ulCount;
+	}
+	ATOMIC_EXIT_CRITICAL();
+
+	return ulCurrent;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * Atomic subtract
+ *
+ * @brief Atomically subtracts count from the value of the specified pointer
+ *        pointers to.
+ *
+ * @param[in,out] pulAddend  Pointer to memory location from where value is to be
+ *                         loaded and written back to.
+ * @param[in] ulCount      Value to be subtract from *pulAddend.
+ *
+ * @return previous *pulAddend value.
+ */
+static portFORCE_INLINE uint32_t Atomic_Subtract_u32( uint32_t volatile * pulAddend,
+													  uint32_t ulCount )
+{
+	uint32_t ulCurrent;
+
+	ATOMIC_ENTER_CRITICAL();
+	{
+		ulCurrent = *pulAddend;
+		*pulAddend -= ulCount;
+	}
+	ATOMIC_EXIT_CRITICAL();
+
+	return ulCurrent;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * Atomic increment
+ *
+ * @brief Atomically increments the value of the specified pointer points to.
+ *
+ * @param[in,out] pulAddend  Pointer to memory location from where value is to be
+ *                         loaded and written back to.
+ *
+ * @return *pulAddend value before increment.
+ */
+static portFORCE_INLINE uint32_t Atomic_Increment_u32( uint32_t volatile * pulAddend )
+{
+uint32_t ulCurrent;
+
+	ATOMIC_ENTER_CRITICAL();
+	{
+		ulCurrent = *pulAddend;
+		*pulAddend += 1;
+	}
+	ATOMIC_EXIT_CRITICAL();
+
+	return ulCurrent;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * Atomic decrement
+ *
+ * @brief Atomically decrements the value of the specified pointer points to
+ *
+ * @param[in,out] pulAddend  Pointer to memory location from where value is to be
+ *                         loaded and written back to.
+ *
+ * @return *pulAddend value before decrement.
+ */
+static portFORCE_INLINE uint32_t Atomic_Decrement_u32( uint32_t volatile * pulAddend )
+{
+uint32_t ulCurrent;
+
+	ATOMIC_ENTER_CRITICAL();
+	{
+		ulCurrent = *pulAddend;
+		*pulAddend -= 1;
+	}
+	ATOMIC_EXIT_CRITICAL();
+
+	return ulCurrent;
+}
+
+/*----------------------------- Bitwise Logical ------------------------------*/
+
+/**
+ * Atomic OR
+ *
+ * @brief Performs an atomic OR operation on the specified values.
+ *
+ * @param [in, out] pulDestination  Pointer to memory location from where value is
+ *                                to be loaded and written back to.
+ * @param [in] ulValue            Value to be ORed with *pulDestination.
+ *
+ * @return The original value of *pulDestination.
+ */
+static portFORCE_INLINE uint32_t Atomic_OR_u32( uint32_t volatile * pulDestination,
+												uint32_t ulValue )
+{
+uint32_t ulCurrent;
+
+	ATOMIC_ENTER_CRITICAL();
+	{
+		ulCurrent = *pulDestination;
+		*pulDestination |= ulValue;
+	}
+	ATOMIC_EXIT_CRITICAL();
+
+	return ulCurrent;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * Atomic AND
+ *
+ * @brief Performs an atomic AND operation on the specified values.
+ *
+ * @param [in, out] pulDestination  Pointer to memory location from where value is
+ *                                to be loaded and written back to.
+ * @param [in] ulValue            Value to be ANDed with *pulDestination.
+ *
+ * @return The original value of *pulDestination.
+ */
+static portFORCE_INLINE uint32_t Atomic_AND_u32( uint32_t volatile * pulDestination,
+												 uint32_t ulValue )
+{
+uint32_t ulCurrent;
+
+	ATOMIC_ENTER_CRITICAL();
+	{
+		ulCurrent = *pulDestination;
+		*pulDestination &= ulValue;
+	}
+	ATOMIC_EXIT_CRITICAL();
+
+	return ulCurrent;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * Atomic NAND
+ *
+ * @brief Performs an atomic NAND operation on the specified values.
+ *
+ * @param [in, out] pulDestination  Pointer to memory location from where value is
+ *                                to be loaded and written back to.
+ * @param [in] ulValue            Value to be NANDed with *pulDestination.
+ *
+ * @return The original value of *pulDestination.
+ */
+static portFORCE_INLINE uint32_t Atomic_NAND_u32( uint32_t volatile * pulDestination,
+												  uint32_t ulValue )
+{
+uint32_t ulCurrent;
+
+	ATOMIC_ENTER_CRITICAL();
+	{
+		ulCurrent = *pulDestination;
+		*pulDestination = ~( ulCurrent & ulValue );
+	}
+	ATOMIC_EXIT_CRITICAL();
+
+	return ulCurrent;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * Atomic XOR
+ *
+ * @brief Performs an atomic XOR operation on the specified values.
+ *
+ * @param [in, out] pulDestination  Pointer to memory location from where value is
+ *                                to be loaded and written back to.
+ * @param [in] ulValue            Value to be XORed with *pulDestination.
+ *
+ * @return The original value of *pulDestination.
+ */
+static portFORCE_INLINE uint32_t Atomic_XOR_u32( uint32_t volatile * pulDestination,
+												 uint32_t ulValue )
+{
+uint32_t ulCurrent;
+
+	ATOMIC_ENTER_CRITICAL();
+	{
+		ulCurrent = *pulDestination;
+		*pulDestination ^= ulValue;
+	}
+	ATOMIC_EXIT_CRITICAL();
+
+	return ulCurrent;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ATOMIC_H */

--- a/src/FreeRTOS/Source/include/croutine.h
+++ b/src/FreeRTOS/Source/include/croutine.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -157,7 +157,7 @@ BaseType_t xCoRoutineCreate( crCOROUTINE_CODE pxCoRoutineCode, UBaseType_t uxPri
  }
 
  // Alternatively, if you do not require any other part of the idle task to
- // execute, the idle task hook can call vCoRoutineScheduler() within an
+ // execute, the idle task hook can call vCoRoutineSchedule() within an
  // infinite loop.
  void vApplicationIdleHook( void )
  {

--- a/src/FreeRTOS/Source/include/deprecated_definitions.h
+++ b/src/FreeRTOS/Source/include/deprecated_definitions.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/FreeRTOS/Source/include/event_groups.h
+++ b/src/FreeRTOS/Source/include/event_groups.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/FreeRTOS/Source/include/list.h
+++ b/src/FreeRTOS/Source/include/list.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -183,7 +183,7 @@ typedef struct xLIST
  * Access macro to get the owner of a list item.  The owner of a list item
  * is the object (usually a TCB) that contains the list item.
  *
- * \page listSET_LIST_ITEM_OWNER listSET_LIST_ITEM_OWNER
+ * \page listGET_LIST_ITEM_OWNER listSET_LIST_ITEM_OWNER
  * \ingroup LinkedList
  */
 #define listGET_LIST_ITEM_OWNER( pxListItem )	( ( pxListItem )->pvOwner )
@@ -225,7 +225,7 @@ typedef struct xLIST
 #define listGET_HEAD_ENTRY( pxList )	( ( ( pxList )->xListEnd ).pxNext )
 
 /*
- * Return the list item at the head of the list.
+ * Return the next list item.
  *
  * \page listGET_NEXT listGET_NEXT
  * \ingroup LinkedList

--- a/src/FreeRTOS/Source/include/message_buffer.h
+++ b/src/FreeRTOS/Source/include/message_buffer.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -61,6 +61,10 @@
 
 #ifndef FREERTOS_MESSAGE_BUFFER_H
 #define FREERTOS_MESSAGE_BUFFER_H
+
+#ifndef INC_FREERTOS_H
+	#error "include FreeRTOS.h must appear in source files before include message_buffer.h"
+#endif
 
 /* Message buffers are built onto of stream buffers. */
 #include "stream_buffer.h"
@@ -395,10 +399,10 @@ BaseType_t xHigherPriorityTaskWoken = pdFALSE; // Initialised to pdFALSE.
     // priority of the currently executing task was unblocked and a context
     // switch should be performed to ensure the ISR returns to the unblocked
     // task.  In most FreeRTOS ports this is done by simply passing
-    // xHigherPriorityTaskWoken into taskYIELD_FROM_ISR(), which will test the
+    // xHigherPriorityTaskWoken into portYIELD_FROM_ISR(), which will test the
     // variables value, and perform the context switch if necessary.  Check the
     // documentation for the port in use for port specific instructions.
-    taskYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 </pre>
  * \defgroup xMessageBufferSendFromISR xMessageBufferSendFromISR
@@ -584,10 +588,10 @@ BaseType_t xHigherPriorityTaskWoken = pdFALSE;  // Initialised to pdFALSE.
     // priority of the currently executing task was unblocked and a context
     // switch should be performed to ensure the ISR returns to the unblocked
     // task.  In most FreeRTOS ports this is done by simply passing
-    // xHigherPriorityTaskWoken into taskYIELD_FROM_ISR(), which will test the
+    // xHigherPriorityTaskWoken into portYIELD_FROM_ISR(), which will test the
     // variables value, and perform the context switch if necessary.  Check the
     // documentation for the port in use for port specific instructions.
-    taskYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 </pre>
  * \defgroup xMessageBufferReceiveFromISR xMessageBufferReceiveFromISR

--- a/src/FreeRTOS/Source/include/mpu_prototypes.h
+++ b/src/FreeRTOS/Source/include/mpu_prototypes.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -69,19 +69,21 @@ void * MPU_pvTaskGetThreadLocalStoragePointer( TaskHandle_t xTaskToQuery, BaseTy
 BaseType_t MPU_xTaskCallApplicationTaskHook( TaskHandle_t xTask, void *pvParameter ) FREERTOS_SYSTEM_CALL;
 TaskHandle_t MPU_xTaskGetIdleTaskHandle( void ) FREERTOS_SYSTEM_CALL;
 UBaseType_t MPU_uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray, const UBaseType_t uxArraySize, uint32_t * const pulTotalRunTime ) FREERTOS_SYSTEM_CALL;
-TickType_t MPU_xTaskGetIdleRunTimeCounter( void ) FREERTOS_SYSTEM_CALL;
+uint32_t MPU_ulTaskGetIdleRunTimeCounter( void ) FREERTOS_SYSTEM_CALL;
 void MPU_vTaskList( char * pcWriteBuffer ) FREERTOS_SYSTEM_CALL;
 void MPU_vTaskGetRunTimeStats( char *pcWriteBuffer ) FREERTOS_SYSTEM_CALL;
 BaseType_t MPU_xTaskGenericNotify( TaskHandle_t xTaskToNotify, uint32_t ulValue, eNotifyAction eAction, uint32_t *pulPreviousNotificationValue ) FREERTOS_SYSTEM_CALL;
 BaseType_t MPU_xTaskNotifyWait( uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t *pulNotificationValue, TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
 uint32_t MPU_ulTaskNotifyTake( BaseType_t xClearCountOnExit, TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
 BaseType_t MPU_xTaskNotifyStateClear( TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
+uint32_t MPU_ulTaskNotifyValueClear( TaskHandle_t xTask, uint32_t ulBitsToClear ) FREERTOS_SYSTEM_CALL;
 BaseType_t MPU_xTaskIncrementTick( void ) FREERTOS_SYSTEM_CALL;
 TaskHandle_t MPU_xTaskGetCurrentTaskHandle( void ) FREERTOS_SYSTEM_CALL;
 void MPU_vTaskSetTimeOutState( TimeOut_t * const pxTimeOut ) FREERTOS_SYSTEM_CALL;
 BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut, TickType_t * const pxTicksToWait ) FREERTOS_SYSTEM_CALL;
 void MPU_vTaskMissedYield( void ) FREERTOS_SYSTEM_CALL;
 BaseType_t MPU_xTaskGetSchedulerState( void ) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTaskCatchUpTicks( TickType_t xTicksToCatchUp ) FREERTOS_SYSTEM_CALL;
 
 /* MPU versions of queue.h API functions. */
 BaseType_t MPU_xQueueGenericSend( QueueHandle_t xQueue, const void * const pvItemToQueue, TickType_t xTicksToWait, const BaseType_t xCopyPosition ) FREERTOS_SYSTEM_CALL;
@@ -122,6 +124,7 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) FREERTOS_SYSTEM_CALL;
 BaseType_t MPU_xTimerPendFunctionCall( PendedFunction_t xFunctionToPend, void *pvParameter1, uint32_t ulParameter2, TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
 const char * MPU_pcTimerGetName( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
 void MPU_vTimerSetReloadMode( TimerHandle_t xTimer, const UBaseType_t uxAutoReload ) FREERTOS_SYSTEM_CALL;
+UBaseType_t MPU_uxTimerGetReloadMode( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
 TickType_t MPU_xTimerGetPeriod( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
 TickType_t MPU_xTimerGetExpiryTime( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
 BaseType_t MPU_xTimerCreateTimerTask( void ) FREERTOS_SYSTEM_CALL;

--- a/src/FreeRTOS/Source/include/mpu_wrappers.h
+++ b/src/FreeRTOS/Source/include/mpu_wrappers.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -77,11 +77,13 @@ only for ports that are using the MPU. */
 		#define uxTaskGetSystemState					MPU_uxTaskGetSystemState
 		#define vTaskList								MPU_vTaskList
 		#define vTaskGetRunTimeStats					MPU_vTaskGetRunTimeStats
-		#define xTaskGetIdleRunTimeCounter				MPU_xTaskGetIdleRunTimeCounter
+		#define ulTaskGetIdleRunTimeCounter				MPU_ulTaskGetIdleRunTimeCounter
 		#define xTaskGenericNotify						MPU_xTaskGenericNotify
 		#define xTaskNotifyWait							MPU_xTaskNotifyWait
 		#define ulTaskNotifyTake						MPU_ulTaskNotifyTake
 		#define xTaskNotifyStateClear					MPU_xTaskNotifyStateClear
+		#define ulTaskNotifyValueClear					MPU_ulTaskNotifyValueClear
+		#define xTaskCatchUpTicks						MPU_xTaskCatchUpTicks
 
 		#define xTaskGetCurrentTaskHandle				MPU_xTaskGetCurrentTaskHandle
 		#define vTaskSetTimeOutState					MPU_vTaskSetTimeOutState
@@ -127,6 +129,7 @@ only for ports that are using the MPU. */
 		#define xTimerPendFunctionCall					MPU_xTimerPendFunctionCall
 		#define pcTimerGetName							MPU_pcTimerGetName
 		#define vTimerSetReloadMode						MPU_vTimerSetReloadMode
+		#define uxTimerGetReloadMode					MPU_uxTimerGetReloadMode
 		#define xTimerGetPeriod							MPU_xTimerGetPeriod
 		#define xTimerGetExpiryTime						MPU_xTimerGetExpiryTime
 		#define xTimerGenericCommand					MPU_xTimerGenericCommand

--- a/src/FreeRTOS/Source/include/portable.h
+++ b/src/FreeRTOS/Source/include/portable.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -118,12 +118,25 @@ extern "C" {
 	#endif
 #endif
 
-/* Used by heap_5.c. */
+/* Used by heap_5.c to define the start address and size of each memory region
+that together comprise the total FreeRTOS heap space. */
 typedef struct HeapRegion
 {
 	uint8_t *pucStartAddress;
 	size_t xSizeInBytes;
 } HeapRegion_t;
+
+/* Used to pass information about the heap out of vPortGetHeapStats(). */
+typedef struct xHeapStats
+{
+	size_t xAvailableHeapSpaceInBytes;		/* The total heap size currently available - this is the sum of all the free blocks, not the largest block that can be allocated. */
+	size_t xSizeOfLargestFreeBlockInBytes; 	/* The maximum size, in bytes, of all the free blocks within the heap at the time vPortGetHeapStats() is called. */
+	size_t xSizeOfSmallestFreeBlockInBytes; /* The minimum size, in bytes, of all the free blocks within the heap at the time vPortGetHeapStats() is called. */
+	size_t xNumberOfFreeBlocks;				/* The number of free memory blocks within the heap at the time vPortGetHeapStats() is called. */
+	size_t xMinimumEverFreeBytesRemaining;	/* The minimum amount of total free memory (sum of all free blocks) there has been in the heap since the system booted. */
+	size_t xNumberOfSuccessfulAllocations;	/* The number of calls to pvPortMalloc() that have returned a valid memory block. */
+	size_t xNumberOfSuccessfulFrees;		/* The number of calls to vPortFree() that has successfully freed a block of memory. */
+} HeapStats_t;
 
 /*
  * Used to define multiple heap regions for use by heap_5.c.  This function
@@ -138,6 +151,11 @@ typedef struct HeapRegion
  */
 void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) PRIVILEGED_FUNCTION;
 
+/*
+ * Returns a HeapStats_t structure filled with information about the current
+ * heap state.
+ */
+void vPortGetHeapStats( HeapStats_t *pxHeapStats );
 
 /*
  * Map to the memory management routines required for the port.

--- a/src/FreeRTOS/Source/include/projdefs.h
+++ b/src/FreeRTOS/Source/include/projdefs.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/FreeRTOS/Source/include/queue.h
+++ b/src/FreeRTOS/Source/include/queue.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -1284,7 +1284,7 @@ uint32_t ulVarToSend, ulValReceived;
 	// name of the yield function required is port specific.
 	if( xHigherPriorityTaskWokenByPost )
 	{
-		taskYIELD_YIELD_FROM_ISR();
+		portYIELD_FROM_ISR();
 	}
  }
  </pre>

--- a/src/FreeRTOS/Source/include/semphr.h
+++ b/src/FreeRTOS/Source/include/semphr.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/FreeRTOS/Source/include/stack_macros.h
+++ b/src/FreeRTOS/Source/include/stack_macros.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/FreeRTOS/Source/include/stream_buffer.h
+++ b/src/FreeRTOS/Source/include/stream_buffer.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -43,13 +43,17 @@
  * (such as xStreamBufferSend()) inside a critical section and set the send
  * block time to 0.  Likewise, if there are to be multiple different readers
  * then the application writer must place each call to a reading API function
- * (such as xStreamBufferRead()) inside a critical section section and set the
+ * (such as xStreamBufferReceive()) inside a critical section section and set the
  * receive block time to 0.
  *
  */
 
 #ifndef STREAM_BUFFER_H
 #define STREAM_BUFFER_H
+
+#ifndef INC_FREERTOS_H
+	#error "include FreeRTOS.h must appear in source files before include stream_buffer.h"
+#endif
 
 #if defined( __cplusplus )
 extern "C" {
@@ -237,7 +241,7 @@ size_t xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
  * (such as xStreamBufferSend()) inside a critical section and set the send
  * block time to 0.  Likewise, if there are to be multiple different readers
  * then the application writer must place each call to a reading API function
- * (such as xStreamBufferRead()) inside a critical section and set the receive
+ * (such as xStreamBufferReceive()) inside a critical section and set the receive
  * block time to 0.
  *
  * Use xStreamBufferSend() to write to a stream buffer from a task.  Use
@@ -335,7 +339,7 @@ size_t xStreamBufferSendFromISR( StreamBufferHandle_t xStreamBuffer,
  * (such as xStreamBufferSend()) inside a critical section and set the send
  * block time to 0.  Likewise, if there are to be multiple different readers
  * then the application writer must place each call to a reading API function
- * (such as xStreamBufferRead()) inside a critical section and set the receive
+ * (such as xStreamBufferReceive()) inside a critical section and set the receive
  * block time to 0.
  *
  * Use xStreamBufferSend() to write to a stream buffer from a task.  Use
@@ -435,7 +439,7 @@ size_t xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
  * (such as xStreamBufferSend()) inside a critical section and set the send
  * block time to 0.  Likewise, if there are to be multiple different readers
  * then the application writer must place each call to a reading API function
- * (such as xStreamBufferRead()) inside a critical section and set the receive
+ * (such as xStreamBufferReceive()) inside a critical section and set the receive
  * block time to 0.
  *
  * Use xStreamBufferReceive() to read from a stream buffer from a task.  Use

--- a/src/FreeRTOS/Source/include/task.h
+++ b/src/FreeRTOS/Source/include/task.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -43,10 +43,10 @@ extern "C" {
  * MACROS AND DEFINITIONS
  *----------------------------------------------------------*/
 
-#define tskKERNEL_VERSION_NUMBER "V10.2.0"
+#define tskKERNEL_VERSION_NUMBER "V10.3.1"
 #define tskKERNEL_VERSION_MAJOR 10
-#define tskKERNEL_VERSION_MINOR 2
-#define tskKERNEL_VERSION_BUILD 0
+#define tskKERNEL_VERSION_MINOR 3
+#define tskKERNEL_VERSION_BUILD 1
 
 /* MPU region parameters passed in ulParameters
  * of MemoryRegion_t struct. */
@@ -314,13 +314,13 @@ is used in assert() statements. */
 	 // an automatic stack variable it might no longer exist, or at least have been corrupted, by the time
 	 // the new task attempts to access it.
 	 xTaskCreate( vTaskCode, "NAME", STACK_SIZE, &ucParameterToPass, tskIDLE_PRIORITY, &xHandle );
-     configASSERT( xHandle );
+	 configASSERT( xHandle );
 
 	 // Use the handle to delete the task.
-     if( xHandle != NULL )
-     {
-	     vTaskDelete( xHandle );
-     }
+	 if( xHandle != NULL )
+	 {
+	 	vTaskDelete( xHandle );
+	 }
  }
    </pre>
  * \defgroup xTaskCreate xTaskCreate
@@ -498,9 +498,9 @@ static const TaskParameters_t xCheckTaskParameters =
 	// for full information.
 	{
 		// Base address					Length	Parameters
-        { cReadWriteArray,				32,		portMPU_REGION_READ_WRITE },
-        { cReadOnlyArray,				32,		portMPU_REGION_READ_ONLY },
-        { cPrivilegedOnlyAccessArray,	128,	portMPU_REGION_PRIVILEGED_READ_WRITE }
+		{ cReadWriteArray,				32,		portMPU_REGION_READ_WRITE },
+		{ cReadOnlyArray,				32,		portMPU_REGION_READ_ONLY },
+		{ cPrivilegedOnlyAccessArray,	128,	portMPU_REGION_PRIVILEGED_READ_WRITE }
 	}
 };
 
@@ -584,9 +584,9 @@ static const TaskParameters_t xCheckTaskParameters =
 	// for full information.
 	{
 		// Base address					Length	Parameters
-        { cReadWriteArray,				32,		portMPU_REGION_READ_WRITE },
-        { cReadOnlyArray,				32,		portMPU_REGION_READ_ONLY },
-        { cPrivilegedOnlyAccessArray,	128,	portMPU_REGION_PRIVILEGED_READ_WRITE }
+		{ cReadWriteArray,				32,		portMPU_REGION_READ_WRITE },
+		{ cReadOnlyArray,				32,		portMPU_REGION_READ_ONLY },
+		{ cPrivilegedOnlyAccessArray,	128,	portMPU_REGION_PRIVILEGED_READ_WRITE }
 	}
 
 	&xTaskBuffer; // Holds the task's data structure.
@@ -830,6 +830,11 @@ void vTaskDelayUntil( TickType_t * const pxPreviousWakeTime, const TickType_t xT
  * that is in the Blocked state is used in a call to xTaskAbortDelay() then the
  * task will leave the Blocked state, and return from whichever function call
  * placed the task into the Blocked state.
+ *
+ * There is no 'FromISR' version of this function as an interrupt would need to
+ * know which object a task was blocked on in order to know which actions to
+ * take.  For example, if the task was blocked on a queue the interrupt handler
+ * would then need to know if the queue was locked.
  *
  * @param xTask The handle of the task to remove from the Blocked state.
  *
@@ -1738,7 +1743,7 @@ void vTaskGetRunTimeStats( char *pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e9
 
 /**
 * task. h
-* <PRE>TickType_t xTaskGetIdleRunTimeCounter( void );</PRE>
+* <PRE>uint32_t ulTaskGetIdleRunTimeCounter( void );</PRE>
 *
 * configGENERATE_RUN_TIME_STATS and configUSE_STATS_FORMATTING_FUNCTIONS
 * must both be defined as 1 for this function to be available.  The application
@@ -1753,7 +1758,7 @@ void vTaskGetRunTimeStats( char *pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e9
 * of the accumulated time value depends on the frequency of the timer
 * configured by the portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() macro.
 * While uxTaskGetSystemState() and vTaskGetRunTimeStats() writes the total
-* execution time of each task into a buffer, xTaskGetIdleRunTimeCounter()
+* execution time of each task into a buffer, ulTaskGetIdleRunTimeCounter()
 * returns the total execution time of just the idle task.
 *
 * @return The total run time of the idle task.  This is the amount of time the
@@ -1761,10 +1766,10 @@ void vTaskGetRunTimeStats( char *pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e9
 * frequency configured using the portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() and
 * portGET_RUN_TIME_COUNTER_VALUE() macros.
 *
-* \defgroup xTaskGetIdleRunTimeCounter xTaskGetIdleRunTimeCounter
+* \defgroup ulTaskGetIdleRunTimeCounter ulTaskGetIdleRunTimeCounter
 * \ingroup TaskUtils
 */
-TickType_t xTaskGetIdleRunTimeCounter( void ) PRIVILEGED_FUNCTION;
+uint32_t ulTaskGetIdleRunTimeCounter( void ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
@@ -2201,6 +2206,121 @@ uint32_t ulTaskNotifyTake( BaseType_t xClearCountOnExit, TickType_t xTicksToWait
  */
 BaseType_t xTaskNotifyStateClear( TaskHandle_t xTask );
 
+/**
+* task. h
+* <PRE>uint32_t ulTaskNotifyValueClear( TaskHandle_t xTask, uint32_t ulBitsToClear );</pre>
+*
+* Clears the bits specified by the ulBitsToClear bit mask in the notification
+* value of the task referenced by xTask.
+*
+* Set ulBitsToClear to 0xffffffff (UINT_MAX on 32-bit architectures) to clear
+* the notification value to 0.  Set ulBitsToClear to 0 to query the task's
+* notification value without clearing any bits.
+*
+* @return The value of the target task's notification value before the bits
+* specified by ulBitsToClear were cleared.
+* \defgroup ulTaskNotifyValueClear ulTaskNotifyValueClear
+* \ingroup TaskNotifications
+*/
+uint32_t ulTaskNotifyValueClear( TaskHandle_t xTask, uint32_t ulBitsToClear ) PRIVILEGED_FUNCTION;
+
+/**
+ * task.h
+ * <pre>void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )</pre>
+ *
+ * Capture the current time for future use with xTaskCheckForTimeOut().
+ *
+ * @param pxTimeOut Pointer to a timeout object into which the current time
+ * is to be captured.  The captured time includes the tick count and the number
+ * of times the tick count has overflowed since the system first booted.
+ * \defgroup vTaskSetTimeOutState vTaskSetTimeOutState
+ * \ingroup TaskCtrl
+ */
+void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNCTION;
+
+/**
+ * task.h
+ * <pre>BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut, TickType_t * const pxTicksToWait );</pre>
+ *
+ * Determines if pxTicksToWait ticks has passed since a time was captured
+ * using a call to vTaskSetTimeOutState().  The captured time includes the tick
+ * count and the number of times the tick count has overflowed.
+ *
+ * @param pxTimeOut The time status as captured previously using
+ * vTaskSetTimeOutState. If the timeout has not yet occurred, it is updated
+ * to reflect the current time status.
+ * @param pxTicksToWait The number of ticks to check for timeout i.e. if
+ * pxTicksToWait ticks have passed since pxTimeOut was last updated (either by
+ * vTaskSetTimeOutState() or xTaskCheckForTimeOut()), the timeout has occurred.
+ * If the timeout has not occurred, pxTIcksToWait is updated to reflect the
+ * number of remaining ticks.
+ *
+ * @return If timeout has occurred, pdTRUE is returned. Otherwise pdFALSE is
+ * returned and pxTicksToWait is updated to reflect the number of remaining
+ * ticks.
+ *
+ * @see https://www.freertos.org/xTaskCheckForTimeOut.html
+ *
+ * Example Usage:
+ * <pre>
+	// Driver library function used to receive uxWantedBytes from an Rx buffer
+	// that is filled by a UART interrupt. If there are not enough bytes in the
+	// Rx buffer then the task enters the Blocked state until it is notified that
+	// more data has been placed into the buffer. If there is still not enough
+	// data then the task re-enters the Blocked state, and xTaskCheckForTimeOut()
+	// is used to re-calculate the Block time to ensure the total amount of time
+	// spent in the Blocked state does not exceed MAX_TIME_TO_WAIT. This
+	// continues until either the buffer contains at least uxWantedBytes bytes,
+	// or the total amount of time spent in the Blocked state reaches
+	// MAX_TIME_TO_WAIT – at which point the task reads however many bytes are
+	// available up to a maximum of uxWantedBytes.
+
+	size_t xUART_Receive( uint8_t *pucBuffer, size_t uxWantedBytes )
+	{
+	size_t uxReceived = 0;
+	TickType_t xTicksToWait = MAX_TIME_TO_WAIT;
+	TimeOut_t xTimeOut;
+
+		// Initialize xTimeOut.  This records the time at which this function
+		// was entered.
+		vTaskSetTimeOutState( &xTimeOut );
+
+		// Loop until the buffer contains the wanted number of bytes, or a
+		// timeout occurs.
+		while( UART_bytes_in_rx_buffer( pxUARTInstance ) < uxWantedBytes )
+		{
+			// The buffer didn't contain enough data so this task is going to
+			// enter the Blocked state. Adjusting xTicksToWait to account for
+			// any time that has been spent in the Blocked state within this
+			// function so far to ensure the total amount of time spent in the
+			// Blocked state does not exceed MAX_TIME_TO_WAIT.
+			if( xTaskCheckForTimeOut( &xTimeOut, &xTicksToWait ) != pdFALSE )
+			{
+				//Timed out before the wanted number of bytes were available,
+				// exit the loop.
+				break;
+			}
+
+			// Wait for a maximum of xTicksToWait ticks to be notified that the
+			// receive interrupt has placed more data into the buffer.
+			ulTaskNotifyTake( pdTRUE, xTicksToWait );
+		}
+
+		// Attempt to read uxWantedBytes from the receive buffer into pucBuffer.
+		// The actual number of bytes read (which might be less than
+		// uxWantedBytes) is returned.
+		uxReceived = UART_read_from_receive_buffer( pxUARTInstance,
+													pucBuffer,
+													uxWantedBytes );
+
+		return uxReceived;
+	}
+ </pre>
+ * \defgroup xTaskCheckForTimeOut xTaskCheckForTimeOut
+ * \ingroup TaskCtrl
+ */
+BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut, TickType_t * const pxTicksToWait ) PRIVILEGED_FUNCTION;
+
 /*-----------------------------------------------------------
  * SCHEDULER INTERNALS AVAILABLE FOR PORTING PURPOSES
  *----------------------------------------------------------*/
@@ -2318,17 +2438,6 @@ TickType_t uxTaskResetEventItemValue( void ) PRIVILEGED_FUNCTION;
 TaskHandle_t xTaskGetCurrentTaskHandle( void ) PRIVILEGED_FUNCTION;
 
 /*
- * Capture the current time status for future reference.
- */
-void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNCTION;
-
-/*
- * Compare the time status now with that previously captured to see if the
- * timeout has expired.
- */
-BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut, TickType_t * const pxTicksToWait ) PRIVILEGED_FUNCTION;
-
-/*
  * Shortcut used by the queue implementation to prevent unnecessary call to
  * taskYIELD();
  */
@@ -2382,6 +2491,19 @@ void vTaskSetTaskNumber( TaskHandle_t xTask, const UBaseType_t uxHandle ) PRIVIL
  * equal to the idle period.
  */
 void vTaskStepTick( const TickType_t xTicksToJump ) PRIVILEGED_FUNCTION;
+
+/* Correct the tick count value after the application code has held
+interrupts disabled for an extended period.  xTicksToCatchUp is the number
+of tick interrupts that have been missed due to interrupts being disabled.
+Its value is not computed automatically, so must be computed by the
+application writer.
+
+This function is similar to vTaskStepTick(), however, unlike
+vTaskStepTick(), xTaskCatchUpTicks() may move the tick count forward past a
+time at which a task should be removed from the blocked state.  That means
+tasks may have to be removed from the blocked state as the tick count is
+moved. */
+BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp ) PRIVILEGED_FUNCTION;
 
 /*
  * Only available when configUSE_TICKLESS_IDLE is set to 1.

--- a/src/FreeRTOS/Source/include/timers.h
+++ b/src/FreeRTOS/Source/include/timers.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -121,7 +121,7 @@ typedef void (*PendedFunction_t)( void *, uint32_t );
  * after 100 ticks, then xTimerPeriodInTicks should be set to 100.
  * Alternatively, if the timer must expire after 500ms, then xPeriod can be set
  * to ( 500 / portTICK_PERIOD_MS ) provided configTICK_RATE_HZ is less than or
- * equal to 1000.
+ * equal to 1000.  Time timer period must be greater than 0.
  *
  * @param uxAutoReload If uxAutoReload is set to pdTRUE then the timer will
  * expire repeatedly with a frequency set by the xTimerPeriodInTicks parameter.
@@ -138,9 +138,9 @@ typedef void (*PendedFunction_t)( void *, uint32_t );
  * which is	"void vCallbackFunction( TimerHandle_t xTimer );".
  *
  * @return If the timer is successfully created then a handle to the newly
- * created timer is returned.  If the timer cannot be created (because either
- * there is insufficient FreeRTOS heap remaining to allocate the timer
- * structures, or the timer period was set to 0) then NULL is returned.
+ * created timer is returned.  If the timer cannot be created because there is
+ * insufficient FreeRTOS heap remaining to allocate the timer
+ * structures then NULL is returned.
  *
  * Example usage:
  * @verbatim
@@ -267,7 +267,7 @@ typedef void (*PendedFunction_t)( void *, uint32_t );
  * after 100 ticks, then xTimerPeriodInTicks should be set to 100.
  * Alternatively, if the timer must expire after 500ms, then xPeriod can be set
  * to ( 500 / portTICK_PERIOD_MS ) provided configTICK_RATE_HZ is less than or
- * equal to 1000.
+ * equal to 1000.  The timer period must be greater than 0.
  *
  * @param uxAutoReload If uxAutoReload is set to pdTRUE then the timer will
  * expire repeatedly with a frequency set by the xTimerPeriodInTicks parameter.
@@ -1234,8 +1234,8 @@ const char * pcTimerGetName( TimerHandle_t xTimer ) PRIVILEGED_FUNCTION; /*lint 
 /**
  * void vTimerSetReloadMode( TimerHandle_t xTimer, const UBaseType_t uxAutoReload );
  *
- * Updates a timer to be either an autoreload timer, in which case the timer
- * automatically resets itself each time it expires, or a one shot timer, in
+ * Updates a timer to be either an auto-reload timer, in which case the timer
+ * automatically resets itself each time it expires, or a one-shot timer, in
  * which case the timer will only expire once unless it is manually restarted.
  *
  * @param xTimer The handle of the timer being updated.
@@ -1247,6 +1247,20 @@ const char * pcTimerGetName( TimerHandle_t xTimer ) PRIVILEGED_FUNCTION; /*lint 
  * enter the dormant state after it expires.
  */
 void vTimerSetReloadMode( TimerHandle_t xTimer, const UBaseType_t uxAutoReload ) PRIVILEGED_FUNCTION;
+
+/**
+* UBaseType_t uxTimerGetReloadMode( TimerHandle_t xTimer );
+*
+* Queries a timer to determine if it is an auto-reload timer, in which case the timer
+* automatically resets itself each time it expires, or a one-shot timer, in
+* which case the timer will only expire once unless it is manually restarted.
+*
+* @param xTimer The handle of the timer being queried.
+*
+* @return If the timer is an auto-reload timer then pdTRUE is returned, otherwise
+* pdFALSE is returned.
+*/
+UBaseType_t uxTimerGetReloadMode( TimerHandle_t xTimer ) PRIVILEGED_FUNCTION;
 
 /**
  * TickType_t xTimerGetPeriod( TimerHandle_t xTimer );

--- a/src/FreeRTOS/Source/list.c
+++ b/src/FreeRTOS/Source/list.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/FreeRTOS/Source/queue.c
+++ b/src/FreeRTOS/Source/queue.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -203,7 +203,7 @@ static void prvCopyDataFromQueue( Queue_t * const pxQueue, void * const pvBuffer
 	 * Checks to see if a queue is a member of a queue set, and if so, notifies
 	 * the queue set that the queue contains data.
 	 */
-	static BaseType_t prvNotifyQueueSetContainer( const Queue_t * const pxQueue, const BaseType_t xCopyPosition ) PRIVILEGED_FUNCTION;
+	static BaseType_t prvNotifyQueueSetContainer( const Queue_t * const pxQueue ) PRIVILEGED_FUNCTION;
 #endif
 
 /*
@@ -373,17 +373,10 @@ Queue_t * const pxQueue = xQueue;
 
 		configASSERT( uxQueueLength > ( UBaseType_t ) 0 );
 
-		if( uxItemSize == ( UBaseType_t ) 0 )
-		{
-			/* There is not going to be a queue storage area. */
-			xQueueSizeInBytes = ( size_t ) 0;
-		}
-		else
-		{
-			/* Allocate enough space to hold the maximum number of items that
-			can be in the queue at any time. */
-			xQueueSizeInBytes = ( size_t ) ( uxQueueLength * uxItemSize ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
-		}
+		/* Allocate enough space to hold the maximum number of items that
+		can be in the queue at any time.  It is valid for uxItemSize to be
+		zero in the case the queue is used as a semaphore. */
+		xQueueSizeInBytes = ( size_t ) ( uxQueueLength * uxItemSize ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
 
 		/* Allocate the queue and storage area.  Justification for MISRA
 		deviation as follows:  pvPortMalloc() always ensures returned memory
@@ -777,7 +770,7 @@ Queue_t * const pxQueue = xQueue;
 
 				#if ( configUSE_QUEUE_SETS == 1 )
 				{
-				UBaseType_t uxPreviousMessagesWaiting = pxQueue->uxMessagesWaiting;
+				const UBaseType_t uxPreviousMessagesWaiting = pxQueue->uxMessagesWaiting;
 
 					xYieldRequired = prvCopyDataToQueue( pxQueue, pvItemToQueue, xCopyPosition );
 
@@ -790,7 +783,7 @@ Queue_t * const pxQueue = xQueue;
 							in the queue has not changed. */
 							mtCOVERAGE_TEST_MARKER();
 						}
-						else if( prvNotifyQueueSetContainer( pxQueue, xCopyPosition ) != pdFALSE )
+						else if( prvNotifyQueueSetContainer( pxQueue ) != pdFALSE )
 						{
 							/* The queue is a member of a queue set, and posting
 							to the queue set caused a higher priority task to
@@ -990,6 +983,7 @@ Queue_t * const pxQueue = xQueue;
 		if( ( pxQueue->uxMessagesWaiting < pxQueue->uxLength ) || ( xCopyPosition == queueOVERWRITE ) )
 		{
 			const int8_t cTxLock = pxQueue->cTxLock;
+			const UBaseType_t uxPreviousMessagesWaiting = pxQueue->uxMessagesWaiting;
 
 			traceQUEUE_SEND_FROM_ISR( pxQueue );
 
@@ -1008,7 +1002,14 @@ Queue_t * const pxQueue = xQueue;
 				{
 					if( pxQueue->pxQueueSetContainer != NULL )
 					{
-						if( prvNotifyQueueSetContainer( pxQueue, xCopyPosition ) != pdFALSE )
+						if( ( xCopyPosition == queueOVERWRITE ) && ( uxPreviousMessagesWaiting != ( UBaseType_t ) 0 ) )
+						{
+							/* Do not notify the queue set as an existing item
+							was overwritten in the queue so the number of items
+							in the queue has not changed. */
+							mtCOVERAGE_TEST_MARKER();
+						}
+						else if( prvNotifyQueueSetContainer( pxQueue ) != pdFALSE )
 						{
 							/* The queue is a member of a queue set, and posting
 							to the queue set caused a higher priority task to
@@ -1081,6 +1082,9 @@ Queue_t * const pxQueue = xQueue;
 					{
 						mtCOVERAGE_TEST_MARKER();
 					}
+					
+					/* Not used in this path. */
+					( void ) uxPreviousMessagesWaiting;
 				}
 				#endif /* configUSE_QUEUE_SETS */
 			}
@@ -1173,7 +1177,7 @@ Queue_t * const pxQueue = xQueue;
 				{
 					if( pxQueue->pxQueueSetContainer != NULL )
 					{
-						if( prvNotifyQueueSetContainer( pxQueue, queueSEND_TO_BACK ) != pdFALSE )
+						if( prvNotifyQueueSetContainer( pxQueue ) != pdFALSE )
 						{
 							/* The semaphore is a member of a queue set, and
 							posting	to the queue set caused a higher priority
@@ -2185,7 +2189,7 @@ static void prvUnlockQueue( Queue_t * const pxQueue )
 			{
 				if( pxQueue->pxQueueSetContainer != NULL )
 				{
-					if( prvNotifyQueueSetContainer( pxQueue, queueSEND_TO_BACK ) != pdFALSE )
+					if( prvNotifyQueueSetContainer( pxQueue ) != pdFALSE )
 					{
 						/* The queue is a member of a queue set, and posting to
 						the queue set caused a higher priority task to unblock.
@@ -2875,7 +2879,7 @@ Queue_t * const pxQueue = xQueue;
 
 #if ( configUSE_QUEUE_SETS == 1 )
 
-	static BaseType_t prvNotifyQueueSetContainer( const Queue_t * const pxQueue, const BaseType_t xCopyPosition )
+	static BaseType_t prvNotifyQueueSetContainer( const Queue_t * const pxQueue )
 	{
 	Queue_t *pxQueueSetContainer = pxQueue->pxQueueSetContainer;
 	BaseType_t xReturn = pdFALSE;
@@ -2892,7 +2896,7 @@ Queue_t * const pxQueue = xQueue;
 			traceQUEUE_SEND( pxQueueSetContainer );
 
 			/* The data copied is the handle of the queue that contains data. */
-			xReturn = prvCopyDataToQueue( pxQueueSetContainer, &pxQueue, xCopyPosition );
+			xReturn = prvCopyDataToQueue( pxQueueSetContainer, &pxQueue, queueSEND_TO_BACK );
 
 			if( cTxLock == queueUNLOCKED )
 			{

--- a/src/FreeRTOS/Source/st_readme.txt
+++ b/src/FreeRTOS/Source/st_readme.txt
@@ -25,6 +25,60 @@
 
 =======
 
+### 31-August-2020 ###
+=========================
+  + Bug fix for G0 compilation error due to IRQn_Type mismatch between G0 and other families
+      - Source/CMSIS_RTOS_V2/cmsis_os2.c
+  + Bug fix when using systick as timebasse for HAL
+      - Source/CMSIS_RTOS_V2/cmsis_os2.c
+
+### 20-July-2020 ###
+=========================
+  + FreeRTOS: Update to FreeRTOS v10.3.1
+  
+  + CMSIS_RTOS_V2: update against the latest CMSIS-FreeRTOS v10.3.0 release
+      - CMSIS_RTOS_V2/cmsis_os2.c
+      - CMSIS_RTOS_V2/freertos_mpool.h
+      - CMSIS_RTOS_V2/freertos_os2.h
+      - CMSIS_RTOS_V2/os_systick.c
+
+  + Add Tickless Idle support for CM23/CM33
+      - GCC/ARM_CM23/non_secure/port.c
+      - GCC/ARM_CM23/non_secure/portmacro.h
+      - GCC/ARM_CM23_NTZ/non_secure/port.c
+      - GCC/ARM_CM23_NTZ/non_secure/portmacro.h
+      - GCC/ARM_CM33/non_secure/port.c
+      - GCC/ARM_CM33/non_secure/portmacro.h
+      - GCC/ARM_CM33_NTZ/non_secure/port.c
+      - GCC/ARM_CM33_NTZ/non_secure/portmacro.h
+      - IAR/ARM_CM23/non_secure/port.c
+      - IAR/ARM_CM23/non_secure/portmacro.h
+      - IAR/ARM_CM23_NTZ/non_secure/port.c
+      - IAR/ARM_CM23_NTZ/non_secure/portmacro.h
+      - IAR/ARM_CM33/non_secure/port.c
+      - IAR/ARM_CM33/non_secure/portmacro.h
+      - IAR/ARM_CM33_NTZ/non_secure/port.c
+      - IAR/ARM_CM33_NTZ/non_secure/portmacro.h
+  
+  +  Fix MPU hardfault bug for Cortex-M4 MPU
+      - GCC\ARM_CM4_MPU\port.c
+      - IAR\ARM_CM4_MPU\port.c
+      - RVDS\ARM_CM4_MPU\port.c
+
+  +  Add support for 16 MPU regions to Cortex-M4 MPU ports
+      - GCC/ARM_CM4_MPU/portmacro.h
+      - IAR/ARM_CM4_MPU/portmacro.h
+      - RVDS/ARM_CM4_MPU/portmacro.h
+
+  + Update ARM_CM7_MPU source files for all compilers
+      - GCC/ARM_CM7_MPU/r0p1/port.c
+      - GCC/ARM_CM7_MPU/r0p1/portmacro.h
+      - IAR/ARM_CM7_MPU/r0p1/port.c
+      - IAR/ARM_CM7_MPU/r0p1/portasm.s
+      - IAR/ARM_CM7_MPU/r0p1/portmacro.h
+      - RVDS/ARM_CM7_MPU/r0p1/port.c
+      - RVDS/ARM_CM7_MPU/r0p1/portmacro.h
+
 ### 17-January-2020 ###
 =========================
   + Fix compile error in the GCC CM7_MPU port caused by a duplicated variable declaration

--- a/src/FreeRTOS/Source/stream_buffer.c
+++ b/src/FreeRTOS/Source/stream_buffer.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/FreeRTOS/Source/tasks.c
+++ b/src/FreeRTOS/Source/tasks.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -300,7 +300,10 @@ typedef struct tskTaskControlBlock 			/* The old naming convention is used to pr
 		responsible for resulting newlib operation.  User must be familiar with
 		newlib and must provide system-wide implementations of the necessary
 		stubs. Be warned that (at the time of writing) the current newlib design
-		implements a system-wide malloc() that must be provided with locks. */
+		implements a system-wide malloc() that must be provided with locks.
+
+		See the third party link http://www.nadler.com/embedded/newlibAndFreeRTOS.html
+		for additional information. */
 		struct	_reent xNewLib_reent;
 	#endif
 
@@ -337,23 +340,23 @@ PRIVILEGED_DATA TCB_t * volatile pxCurrentTCB = NULL;
 xDelayedTaskList1 and xDelayedTaskList2 could be move to function scople but
 doing so breaks some kernel aware debuggers and debuggers that rely on removing
 the static qualifier. */
-PRIVILEGED_DATA static List_t pxReadyTasksLists[ configMAX_PRIORITIES ] = { 0 };/*< Prioritised ready tasks. */
-PRIVILEGED_DATA static List_t xDelayedTaskList1 = { 0 };						/*< Delayed tasks. */
-PRIVILEGED_DATA static List_t xDelayedTaskList2 = { 0 };						/*< Delayed tasks (two lists are used - one for delays that have overflowed the current tick count. */
-PRIVILEGED_DATA static List_t * volatile pxDelayedTaskList = NULL;				/*< Points to the delayed task list currently being used. */
-PRIVILEGED_DATA static List_t * volatile pxOverflowDelayedTaskList = NULL;		/*< Points to the delayed task list currently being used to hold tasks that have overflowed the current tick count. */
-PRIVILEGED_DATA static List_t xPendingReadyList = { 0 };						/*< Tasks that have been readied while the scheduler was suspended.  They will be moved to the ready list when the scheduler is resumed. */
+PRIVILEGED_DATA static List_t pxReadyTasksLists[ configMAX_PRIORITIES ];/*< Prioritised ready tasks. */
+PRIVILEGED_DATA static List_t xDelayedTaskList1;						/*< Delayed tasks. */
+PRIVILEGED_DATA static List_t xDelayedTaskList2;						/*< Delayed tasks (two lists are used - one for delays that have overflowed the current tick count. */
+PRIVILEGED_DATA static List_t * volatile pxDelayedTaskList;				/*< Points to the delayed task list currently being used. */
+PRIVILEGED_DATA static List_t * volatile pxOverflowDelayedTaskList;		/*< Points to the delayed task list currently being used to hold tasks that have overflowed the current tick count. */
+PRIVILEGED_DATA static List_t xPendingReadyList;						/*< Tasks that have been readied while the scheduler was suspended.  They will be moved to the ready list when the scheduler is resumed. */
 
 #if( INCLUDE_vTaskDelete == 1 )
 
-PRIVILEGED_DATA static List_t xTasksWaitingTermination = { 0 };				/*< Tasks that have been deleted - but their memory not yet freed. */
+	PRIVILEGED_DATA static List_t xTasksWaitingTermination;				/*< Tasks that have been deleted - but their memory not yet freed. */
 	PRIVILEGED_DATA static volatile UBaseType_t uxDeletedTasksWaitingCleanUp = ( UBaseType_t ) 0U;
 
 #endif
 
 #if ( INCLUDE_vTaskSuspend == 1 )
 
-	PRIVILEGED_DATA static List_t xSuspendedTaskList = { 0 };					/*< Tasks that are currently suspended. */
+	PRIVILEGED_DATA static List_t xSuspendedTaskList;					/*< Tasks that are currently suspended. */
 
 #endif
 
@@ -368,7 +371,7 @@ PRIVILEGED_DATA static volatile UBaseType_t uxCurrentNumberOfTasks 	= ( UBaseTyp
 PRIVILEGED_DATA static volatile TickType_t xTickCount 				= ( TickType_t ) configINITIAL_TICK_COUNT;
 PRIVILEGED_DATA static volatile UBaseType_t uxTopReadyPriority 		= tskIDLE_PRIORITY;
 PRIVILEGED_DATA static volatile BaseType_t xSchedulerRunning 		= pdFALSE;
-PRIVILEGED_DATA static volatile UBaseType_t uxPendedTicks 			= ( UBaseType_t ) 0U;
+PRIVILEGED_DATA static volatile TickType_t xPendedTicks 			= ( TickType_t ) 0U;
 PRIVILEGED_DATA static volatile BaseType_t xYieldPending 			= pdFALSE;
 PRIVILEGED_DATA static volatile BaseType_t xNumOfOverflows 			= ( BaseType_t ) 0;
 PRIVILEGED_DATA static UBaseType_t uxTaskNumber 					= ( UBaseType_t ) 0U;
@@ -993,7 +996,9 @@ UBaseType_t x;
 
 	#if ( configUSE_NEWLIB_REENTRANT == 1 )
 	{
-		/* Initialise this task's Newlib reent structure. */
+		/* Initialise this task's Newlib reent structure.
+		See the third party link http://www.nadler.com/embedded/newlibAndFreeRTOS.html
+		for additional information. */
 		_REENT_INIT_PTR( ( &( pxNewTCB->xNewLib_reent ) ) );
 	}
 	#endif
@@ -1164,7 +1169,7 @@ static void prvAddNewTaskToReadyList( TCB_t *pxNewTCB )
 			being deleted. */
 			pxTCB = prvGetTCBFromHandle( xTaskToDelete );
 
-			/* Remove task from the ready list. */
+			/* Remove task from the ready/delayed list. */
 			if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
 			{
 				taskRESET_READY_PRIORITY( pxTCB->uxPriority );
@@ -1204,6 +1209,10 @@ static void prvAddNewTaskToReadyList( TCB_t *pxNewTCB )
 				check the xTasksWaitingTermination list. */
 				++uxDeletedTasksWaitingCleanUp;
 
+				/* Call the delete hook before portPRE_TASK_DELETE_HOOK() as
+				portPRE_TASK_DELETE_HOOK() does not return in the Win32 port. */
+				traceTASK_DELETE( pxTCB );
+
 				/* The pre-delete hook is primarily for the Windows simulator,
 				in which Windows specific clean up operations are performed,
 				after which it is not possible to yield away from this task -
@@ -1214,14 +1223,13 @@ static void prvAddNewTaskToReadyList( TCB_t *pxNewTCB )
 			else
 			{
 				--uxCurrentNumberOfTasks;
+				traceTASK_DELETE( pxTCB );
 				prvDeleteTCB( pxTCB );
 
 				/* Reset the next expected unblock time in case it referred to
 				the task that has just been deleted. */
 				prvResetNextTaskUnblockTime();
 			}
-
-			traceTASK_DELETE( pxTCB );
 		}
 		taskEXIT_CRITICAL();
 
@@ -2041,7 +2049,9 @@ BaseType_t xReturn;
 		#if ( configUSE_NEWLIB_REENTRANT == 1 )
 		{
 			/* Switch Newlib's _impure_ptr variable to point to the _reent
-			structure specific to the task that will run first. */
+			structure specific to the task that will run first.
+			See the third party link http://www.nadler.com/embedded/newlibAndFreeRTOS.html
+			for additional information. */
 			_impure_ptr = &( pxCurrentTCB->xNewLib_reent );
 		}
 		#endif /* configUSE_NEWLIB_REENTRANT */
@@ -2103,7 +2113,17 @@ void vTaskSuspendAll( void )
 	BaseType_t.  Please read Richard Barry's reply in the following link to a
 	post in the FreeRTOS support forum before reporting this as a bug! -
 	http://goo.gl/wu4acr */
+
+	/* portSOFRWARE_BARRIER() is only implemented for emulated/simulated ports that
+	do not otherwise exhibit real time behaviour. */
+	portSOFTWARE_BARRIER();
+
+	/* The scheduler is suspended if uxSchedulerSuspended is non-zero.  An increment
+	is used to allow calls to vTaskSuspendAll() to nest. */
 	++uxSchedulerSuspended;
+
+	/* Enforces ordering for ports and optimised compilers that may otherwise place
+	the above increment elsewhere. */
 	portMEMORY_BARRIER();
 }
 /*----------------------------------------------------------*/
@@ -2230,9 +2250,9 @@ BaseType_t xAlreadyYielded = pdFALSE;
 				not	slip, and that any delayed tasks are resumed at the correct
 				time. */
 				{
-					UBaseType_t uxPendedCounts = uxPendedTicks; /* Non-volatile copy. */
+					TickType_t xPendedCounts = xPendedTicks; /* Non-volatile copy. */
 
-					if( uxPendedCounts > ( UBaseType_t ) 0U )
+					if( xPendedCounts > ( TickType_t ) 0U )
 					{
 						do
 						{
@@ -2244,10 +2264,10 @@ BaseType_t xAlreadyYielded = pdFALSE;
 							{
 								mtCOVERAGE_TEST_MARKER();
 							}
-							--uxPendedCounts;
-						} while( uxPendedCounts > ( UBaseType_t ) 0U );
+							--xPendedCounts;
+						} while( xPendedCounts > ( TickType_t ) 0U );
 
-						uxPendedTicks = 0;
+						xPendedTicks = 0;
 					}
 					else
 					{
@@ -2586,6 +2606,24 @@ implementations require configUSE_TICKLESS_IDLE to be set to a value other than
 #endif /* configUSE_TICKLESS_IDLE */
 /*----------------------------------------------------------*/
 
+BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
+{
+BaseType_t xYieldRequired = pdFALSE;
+
+	/* Must not be called with the scheduler suspended as the implementation
+	relies on xPendedTicks being wound down to 0 in xTaskResumeAll(). */
+	configASSERT( uxSchedulerSuspended == 0 );
+
+	/* Use xPendedTicks to mimic xTicksToCatchUp number of ticks occurring when
+	the scheduler is suspended so the ticks are executed in xTaskResumeAll(). */
+	vTaskSuspendAll();
+	xPendedTicks += xTicksToCatchUp;
+	xYieldRequired = xTaskResumeAll();
+
+	return xYieldRequired;
+}
+/*----------------------------------------------------------*/
+
 #if ( INCLUDE_xTaskAbortDelay == 1 )
 
 	BaseType_t xTaskAbortDelay( TaskHandle_t xTask )
@@ -2617,6 +2655,10 @@ implementations require configUSE_TICKLESS_IDLE to be set to a value other than
 					if( listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) ) != NULL )
 					{
 						( void ) uxListRemove( &( pxTCB->xEventListItem ) );
+
+						/* This lets the task know it was forcibly removed from the
+						blocked state so it should not re-evaluate its block time and
+						then block again. */
 						pxTCB->ucDelayAborted = pdTRUE;
 					}
 					else
@@ -2793,7 +2835,7 @@ BaseType_t xSwitchRequired = pdFALSE;
 		{
 			/* Guard against the tick hook being called when the pended tick
 			count is being unwound (when the scheduler is being unlocked). */
-			if( uxPendedTicks == ( UBaseType_t ) 0U )
+			if( xPendedTicks == ( TickType_t ) 0 )
 			{
 				vApplicationTickHook();
 			}
@@ -2803,10 +2845,23 @@ BaseType_t xSwitchRequired = pdFALSE;
 			}
 		}
 		#endif /* configUSE_TICK_HOOK */
+
+		#if ( configUSE_PREEMPTION == 1 )
+		{
+			if( xYieldPending != pdFALSE )
+			{
+				xSwitchRequired = pdTRUE;
+			}
+			else
+			{
+				mtCOVERAGE_TEST_MARKER();
+			}
+		}
+		#endif /* configUSE_PREEMPTION */
 	}
 	else
 	{
-		++uxPendedTicks;
+		++xPendedTicks;
 
 		/* The tick hook gets called at regular intervals, even if the
 		scheduler is locked. */
@@ -2816,19 +2871,6 @@ BaseType_t xSwitchRequired = pdFALSE;
 		}
 		#endif
 	}
-
-	#if ( configUSE_PREEMPTION == 1 )
-	{
-		if( xYieldPending != pdFALSE )
-		{
-			xSwitchRequired = pdTRUE;
-		}
-		else
-		{
-			mtCOVERAGE_TEST_MARKER();
-		}
-	}
-	#endif /* configUSE_PREEMPTION */
 
 	return xSwitchRequired;
 }
@@ -3009,7 +3051,9 @@ void vTaskSwitchContext( void )
 		#if ( configUSE_NEWLIB_REENTRANT == 1 )
 		{
 			/* Switch Newlib's _impure_ptr variable to point to the _reent
-			structure specific to this task. */
+			structure specific to this task.
+			See the third party link http://www.nadler.com/embedded/newlibAndFreeRTOS.html
+			for additional information. */
 			_impure_ptr = &( pxCurrentTCB->xNewLib_reent );
 		}
 		#endif /* configUSE_NEWLIB_REENTRANT */
@@ -3175,6 +3219,20 @@ TCB_t *pxUnblockedTCB;
 	pxUnblockedTCB = listGET_LIST_ITEM_OWNER( pxEventListItem ); /*lint !e9079 void * is used as this macro is used with timers and co-routines too.  Alignment is known to be fine as the type of the pointer stored and retrieved is the same. */
 	configASSERT( pxUnblockedTCB );
 	( void ) uxListRemove( pxEventListItem );
+
+	#if( configUSE_TICKLESS_IDLE != 0 )
+	{
+		/* If a task is blocked on a kernel object then xNextTaskUnblockTime
+		might be set to the blocked task's time out time.  If the task is
+		unblocked for a reason other than a timeout xNextTaskUnblockTime is
+		normally left unchanged, because it is automatically reset to a new
+		value when the tick count equals xNextTaskUnblockTime.  However if
+		tickless idling is used it might be more important to enter sleep mode
+		at the earliest possible time - so reset xNextTaskUnblockTime here to
+		ensure it is updated at the earliest possible time. */
+		prvResetNextTaskUnblockTime();
+	}
+	#endif
 
 	/* Remove the task from the delayed list and add it to the ready list.  The
 	scheduler is suspended so interrupts will not be accessing the ready
@@ -3456,6 +3514,8 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
 	const UBaseType_t uxNonApplicationTasks = 1;
 	eSleepModeStatus eReturn = eStandardSleep;
 
+		/* This function must be called from a critical section. */
+
 		if( listCURRENT_LIST_LENGTH( &xPendingReadyList ) != 0 )
 		{
 			/* A task was made ready while the scheduler was suspended. */
@@ -3497,6 +3557,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
 		if( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS )
 		{
 			pxTCB = prvGetTCBFromHandle( xTaskToSet );
+			configASSERT( pxTCB != NULL );
 			pxTCB->pvThreadLocalStoragePointers[ xIndex ] = pvValue;
 		}
 	}
@@ -3831,7 +3892,9 @@ static void prvCheckTasksWaitingTermination( void )
 		portCLEAN_UP_TCB( pxTCB );
 
 		/* Free up the memory allocated by the scheduler for the task.  It is up
-		to the task to free any memory allocated at the application level. */
+		to the task to free any memory allocated at the application level.
+		See the third party link http://www.nadler.com/embedded/newlibAndFreeRTOS.html
+		for additional information. */
 		#if ( configUSE_NEWLIB_REENTRANT == 1 )
 		{
 			_reclaim_reent( &( pxTCB->xNewLib_reent ) );
@@ -3981,7 +4044,10 @@ TCB_t *pxTCB;
 				{
 					if( uxListRemove( &( pxMutexHolderTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
 					{
-						taskRESET_READY_PRIORITY( pxMutexHolderTCB->uxPriority );
+						/* It is known that the task is in its ready list so
+						there is no need to check again and the port level
+						reset macro can be called directly. */
+						portRESET_READY_PRIORITY( pxMutexHolderTCB->uxPriority, uxTopReadyPriority );
 					}
 					else
 					{
@@ -4061,7 +4127,7 @@ TCB_t *pxTCB;
 					the mutex.  If the mutex is held by a task then it cannot be
 					given from an interrupt, and if a mutex is given by the
 					holding task then it must be the running state task.  Remove
-					the holding task from the ready list. */
+					the holding task from the ready/delayed list. */
 					if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
 					{
 						taskRESET_READY_PRIORITY( pxTCB->uxPriority );
@@ -4182,7 +4248,10 @@ TCB_t *pxTCB;
 					{
 						if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
 						{
-							taskRESET_READY_PRIORITY( pxTCB->uxPriority );
+							/* It is known that the task is in its ready list so
+							there is no need to check again and the port level
+							reset macro can be called directly. */
+							portRESET_READY_PRIORITY( pxTCB->uxPriority, uxTopReadyPriority );
 						}
 						else
 						{
@@ -5036,7 +5105,6 @@ TickType_t uxReturn;
 	}
 
 #endif /* configUSE_TASK_NOTIFICATIONS */
-
 /*-----------------------------------------------------------*/
 
 #if( configUSE_TASK_NOTIFICATIONS == 1 )
@@ -5070,11 +5138,39 @@ TickType_t uxReturn;
 #endif /* configUSE_TASK_NOTIFICATIONS */
 /*-----------------------------------------------------------*/
 
+#if( configUSE_TASK_NOTIFICATIONS == 1 )
+
+	uint32_t ulTaskNotifyValueClear( TaskHandle_t xTask, uint32_t ulBitsToClear )
+	{
+	TCB_t *pxTCB;
+	uint32_t ulReturn;
+
+		/* If null is passed in here then it is the calling task that is having
+		its notification state cleared. */
+		pxTCB = prvGetTCBFromHandle( xTask );
+
+		taskENTER_CRITICAL();
+		{
+			/* Return the notification as it was before the bits were cleared,
+			then clear the bit mask. */
+			ulReturn = pxCurrentTCB->ulNotifiedValue;
+			pxTCB->ulNotifiedValue &= ~ulBitsToClear;
+		}
+		taskEXIT_CRITICAL();
+
+		return ulReturn;
+	}
+
+#endif /* configUSE_TASK_NOTIFICATIONS */
+/*-----------------------------------------------------------*/
+
 #if( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( INCLUDE_xTaskGetIdleTaskHandle == 1 ) )
-	TickType_t xTaskGetIdleRunTimeCounter( void )
+
+	uint32_t ulTaskGetIdleRunTimeCounter( void )
 	{
 		return xIdleTaskHandle->ulRunTimeCounter;
 	}
+
 #endif
 /*-----------------------------------------------------------*/
 

--- a/src/FreeRTOS/Source/timers.c
+++ b/src/FreeRTOS/Source/timers.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS Kernel V10.2.1
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -132,10 +132,10 @@ timer service task is allowed to access these lists.
 xActiveTimerList1 and xActiveTimerList2 could be at function scope but that
 breaks some kernel aware debuggers, and debuggers that reply on removing the
 static qualifier. */
-PRIVILEGED_DATA static List_t xActiveTimerList1 = { 0 };
-PRIVILEGED_DATA static List_t xActiveTimerList2 = { 0 };
-PRIVILEGED_DATA static List_t *pxCurrentTimerList = NULL;
-PRIVILEGED_DATA static List_t *pxOverflowTimerList = NULL;
+PRIVILEGED_DATA static List_t xActiveTimerList1;
+PRIVILEGED_DATA static List_t xActiveTimerList2;
+PRIVILEGED_DATA static List_t *pxCurrentTimerList;
+PRIVILEGED_DATA static List_t *pxOverflowTimerList;
 
 /* A queue that is used to send commands to the timer service task. */
 PRIVILEGED_DATA static QueueHandle_t xTimerQueue = NULL;
@@ -182,7 +182,7 @@ static BaseType_t prvInsertTimerInActiveList( Timer_t * const pxTimer, const Tic
 
 /*
  * An active timer has reached its expire time.  Reload the timer if it is an
- * auto reload timer, then call its callback.
+ * auto-reload timer, then call its callback.
  */
 static void prvProcessExpiredTimer( const TickType_t xNextExpireTime, const TickType_t xTimeNow ) PRIVILEGED_FUNCTION;
 
@@ -292,7 +292,7 @@ BaseType_t xReturn = pdFAIL;
 		if( pxNewTimer != NULL )
 		{
 			/* Status is thus far zero as the timer is not created statically
-			and has not been started.  The autoreload bit may get set in
+			and has not been started.  The auto-reload bit may get set in
 			prvInitialiseNewTimer. */
 			pxNewTimer->ucStatus = 0x00;
 			prvInitialiseNewTimer( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction, pxNewTimer );
@@ -334,7 +334,7 @@ BaseType_t xReturn = pdFAIL;
 		{
 			/* Timers can be created statically or dynamically so note this
 			timer was created statically in case it is later deleted.  The
-			autoreload bit may get set in prvInitialiseNewTimer(). */
+			auto-reload bit may get set in prvInitialiseNewTimer(). */
 			pxNewTimer->ucStatus = tmrSTATUS_IS_STATICALLY_ALLOCATED;
 
 			prvInitialiseNewTimer( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction, pxNewTimer );
@@ -459,6 +459,31 @@ Timer_t * pxTimer =  xTimer;
 }
 /*-----------------------------------------------------------*/
 
+UBaseType_t uxTimerGetReloadMode( TimerHandle_t xTimer )
+{
+Timer_t * pxTimer =  xTimer;
+UBaseType_t uxReturn;
+
+	configASSERT( xTimer );
+	taskENTER_CRITICAL();
+	{
+		if( ( pxTimer->ucStatus & tmrSTATUS_IS_AUTORELOAD ) == 0 )
+		{
+			/* Not an auto-reload timer. */
+			uxReturn = ( UBaseType_t ) pdFALSE;
+		}
+		else
+		{
+			/* Is an auto-reload timer. */
+			uxReturn = ( UBaseType_t ) pdTRUE;
+		}
+	}
+	taskEXIT_CRITICAL();
+
+	return uxReturn;
+}
+/*-----------------------------------------------------------*/
+
 TickType_t xTimerGetExpiryTime( TimerHandle_t xTimer )
 {
 Timer_t * pxTimer =  xTimer;
@@ -489,7 +514,7 @@ Timer_t * const pxTimer = ( Timer_t * ) listGET_OWNER_OF_HEAD_ENTRY( pxCurrentTi
 	( void ) uxListRemove( &( pxTimer->xTimerListItem ) );
 	traceTIMER_EXPIRED( pxTimer );
 
-	/* If the timer is an auto reload timer then calculate the next
+	/* If the timer is an auto-reload timer then calculate the next
 	expiry time and re-insert the timer in the list of active timers. */
 	if( ( pxTimer->ucStatus & tmrSTATUS_IS_AUTORELOAD ) != 0 )
 	{

--- a/src/FreeRTOS/links_to_doc_pages_for_the_demo_projects.url
+++ b/src/FreeRTOS/links_to_doc_pages_for_the_demo_projects.url
@@ -1,5 +1,0 @@
-[{000214A0-0000-0000-C000-000000000046}]
-Prop3=19,2
-[InternetShortcut]
-URL=http://www.freertos.org/a00090.html
-IDList=

--- a/src/FreeRTOSConfig_Default.h
+++ b/src/FreeRTOSConfig_Default.h
@@ -23,11 +23,10 @@
  * http://aws.amazon.com/freertos
  *
  * 1 tab == 4 spaces!
-*/
+ */
 
-
-#ifndef FREERTOS_CONFIG_H
-#define FREERTOS_CONFIG_H
+#ifndef FREERTOS_CONFIG_DEFAULT_H
+#define FREERTOS_CONFIG_DEFAULT_H
 
 /*-----------------------------------------------------------
  * Application specific definitions.
@@ -140,28 +139,38 @@ extern char _Min_Stack_Size; /* Defined in the linker script */
  */
 #define configUSE_NEWLIB_REENTRANT        1
 
+/* Set configENABLE_MPU to 1 to enable MPU support and 0 to disable it. This is
+currently used in ARMv8M ports. */
+#define configENABLE_MPU                  0
+/* Set configENABLE_FPU to 1 to enable FPU support and 0 to disable it. This is
+currently used in ARMv8M ports. */
+#define configENABLE_FPU                  1
+/* Set configENABLE_TRUSTZONE to 1 enable TrustZone support and 0 to disable it.
+This is currently used in ARMv8M ports. */
+#define configENABLE_TRUSTZONE            0
+
 /* Co-routine definitions. */
-#define configUSE_CO_ROUTINES           0
-#define configMAX_CO_ROUTINE_PRIORITIES (2)
+#define configUSE_CO_ROUTINES             0
+#define configMAX_CO_ROUTINE_PRIORITIES  (2)
 
 /* Software timer definitions. */
-#define configUSE_TIMERS             1
-#define configTIMER_TASK_PRIORITY    (2)
-#define configTIMER_QUEUE_LENGTH     10
-#define configTIMER_TASK_STACK_DEPTH (configMINIMAL_STACK_SIZE * 2)
+#define configUSE_TIMERS                  1
+#define configTIMER_TASK_PRIORITY        (2)
+#define configTIMER_QUEUE_LENGTH         10
+#define configTIMER_TASK_STACK_DEPTH    (configMINIMAL_STACK_SIZE * 2)
 
 /* Set the following definitions to 1 to include the API function, or zero
 to exclude the API function. */
-#define INCLUDE_vTaskPrioritySet       1
-#define INCLUDE_uxTaskPriorityGet      1
-#define INCLUDE_vTaskDelete            1
-#define INCLUDE_vTaskCleanUpResources  1
-#define INCLUDE_vTaskSuspend           1
-#define INCLUDE_vTaskDelayUntil        1
-#define INCLUDE_vTaskDelay             1
-#define INCLUDE_xTaskGetSchedulerState 1
+#define INCLUDE_vTaskPrioritySet          1
+#define INCLUDE_uxTaskPriorityGet         1
+#define INCLUDE_vTaskDelete               1
+#define INCLUDE_vTaskCleanUpResources     1
+#define INCLUDE_vTaskSuspend              1
+#define INCLUDE_vTaskDelayUntil           1
+#define INCLUDE_vTaskDelay                1
+#define INCLUDE_xTaskGetSchedulerState    1
 #define INCLUDE_uxTaskGetStackHighWaterMark 1
-#define INCLUDE_xTaskGetIdleTaskHandle 1
+#define INCLUDE_xTaskGetIdleTaskHandle    1
 
 #if defined(configUSE_CMSIS_RTOS_V2) && (configUSE_CMSIS_RTOS_V2 == 1)
 #define INCLUDE_xSemaphoreGetMutexHolder  1
@@ -173,9 +182,9 @@ to exclude the API function. */
 /* Cortex-M specific definitions. */
 #ifdef __NVIC_PRIO_BITS
  /* __BVIC_PRIO_BITS will be specified when CMSIS is being used. */
- #define configPRIO_BITS         __NVIC_PRIO_BITS
+ #define configPRIO_BITS                  __NVIC_PRIO_BITS
 #else
- #define configPRIO_BITS         4        /* 15 priority levels */
+ #define configPRIO_BITS                  4        /* 15 priority levels */
 #endif
 
 /* The lowest interrupt priority that can be used in a call to a "set priority"
@@ -206,8 +215,7 @@ header file. */
 
 /*
  * IMPORTANT:
- * osSystickHandler is called in the core SysTick_Handler definition
- * and is defined as weak.
+ * osSystickHandler is called in the core SysTick_Handler definition and is defined as weak.
  * For CMSIS-RTOSv2: osSystickHandler is defined as xPortSysTickHandler
  * For CMSIS-RTOS: osSystickHandler is defined by the cmsis_os and xPortSysTickHandler
  * must not be defined to prevent overwriting SysTick_Handler
@@ -217,5 +225,5 @@ header file. */
 #define xPortSysTickHandler osSystickHandler
 #endif
 
-#endif /* FREERTOS_CONFIG_H */
+#endif /* FREERTOS_CONFIG_DEFAULT_H */
 

--- a/src/FreeRTOSConfig_Default.h
+++ b/src/FreeRTOSConfig_Default.h
@@ -83,6 +83,11 @@
 #ifndef configMINIMAL_STACK_SIZE
 #define configMINIMAL_STACK_SIZE          ((uint16_t)128)
 #endif
+
+#if !defined(CMSIS_device_header)
+/* CMSIS_device_header defined to stm32_def.h by default, which include <device.h> like stm32f1xx.h */
+#define CMSIS_device_header  "stm32_def.h"
+#endif /* CMSIS_device_header */
 #else
 #define configMAX_PRIORITIES              (7)
 #endif /* configUSE_CMSIS_RTOS_V2 */
@@ -157,6 +162,13 @@ to exclude the API function. */
 #define INCLUDE_xTaskGetSchedulerState 1
 #define INCLUDE_uxTaskGetStackHighWaterMark 1
 #define INCLUDE_xTaskGetIdleTaskHandle 1
+
+#if defined(configUSE_CMSIS_RTOS_V2) && (configUSE_CMSIS_RTOS_V2 == 1)
+#define INCLUDE_xSemaphoreGetMutexHolder  1
+#define INCLUDE_eTaskGetState             1
+#define INCLUDE_xTimerPendFunctionCall    1
+#define INCLUDE_xTaskGetCurrentTaskHandle 1
+#endif
 
 /* Cortex-M specific definitions. */
 #ifdef __NVIC_PRIO_BITS

--- a/src/FreeRTOSConfig_Default.h
+++ b/src/FreeRTOSConfig_Default.h
@@ -215,15 +215,11 @@ header file. */
 
 /*
  * IMPORTANT:
- * osSystickHandler is called in the core SysTick_Handler definition and is defined as weak.
- * For CMSIS-RTOSv2: osSystickHandler is defined as xPortSysTickHandler
- * For CMSIS-RTOS: osSystickHandler is defined by the cmsis_os and xPortSysTickHandler
- * must not be defined to prevent overwriting SysTick_Handler
+ * SysTick_Handler() from stm32duino core is calling weak osSystickHandler().
+ * Both CMSIS-RTOSv2 and CMSIS-RTOS override osSystickHandler() 
+ * which is calling xPortSysTickHandler(), defined in respective CortexM-x port
  */
 /* #define xPortSysTickHandler SysTick_Handler */
-#if defined(configUSE_CMSIS_RTOS_V2) && (configUSE_CMSIS_RTOS_V2 == 1)
-#define xPortSysTickHandler osSystickHandler
-#endif
 
 #endif /* FREERTOS_CONFIG_DEFAULT_H */
 

--- a/src/freertos_mpool.h
+++ b/src/freertos_mpool.h
@@ -1,0 +1,11 @@
+/*
+ * @file    freertos_mpool.h
+ * @author  Frederic Pillon <frederic.pillon@st.com> for STMicroelectronics.
+ * @brief   Include header file to match Arduino library format
+ */
+#ifndef _ARDUINO_FREERTOS_MPOOL_H_
+#define _ARDUINO_FREERTOS_MPOOL_H_
+
+#include "../portable/CMSIS_RTOS_V2/freertos_mpool.h"
+
+#endif //_ARDUINO_FREERTOS_MPOOL_H_

--- a/src/freertos_os2.h
+++ b/src/freertos_os2.h
@@ -1,0 +1,11 @@
+/*
+ * @file    freertos_os2.h
+ * @author  Frederic Pillon <frederic.pillon@st.com> for STMicroelectronics.
+ * @brief   Include header file to match Arduino library format
+ */
+#ifndef _ARDUINO_FREERTOS_OS2_H_
+#define _ARDUINO_FREERTOS_OS2_H_
+
+#include "../portable/CMSIS_RTOS_V2/freertos_os2.h"
+
+#endif //_ARDUINO_FREERTOS_OS2_H_

--- a/src/mpu_wrappers.h
+++ b/src/mpu_wrappers.h
@@ -1,0 +1,8 @@
+/*
+ * @file    mpu_wrappers.h
+ * @author  Frederic Pillon <frederic.pillon@st.com> for STMicroelectronics.
+ * @brief   Include source file to match Arduino library format
+ */
+
+/* MPU not supported */
+#include "FreeRTOS/Source/include/mpu_wrappers.h"

--- a/src/port.c
+++ b/src/port.c
@@ -9,11 +9,11 @@
 #pragma GCC error  "no \"__CORTEX_M\" definition"
 #endif
 
-#if (__CORTEX_M == 0x00U)
+#if (__CORTEX_M == 0U)
 #include "../portable/GCC/ARM_CM0/port.c"
 #endif
 
-#if (__CORTEX_M == 0x03U)
+#if (__CORTEX_M == 3U)
 /* MPU not supported */
 #if 0 /*(__MPU_PRESENT == 1)*/
 #include "../portable/GCC/ARM_CM3_MPU/port.c"
@@ -22,7 +22,7 @@
 #endif
 #endif
 
-#if (__CORTEX_M == 0x04U)
+#if (__CORTEX_M == 4U)
 /* MPU not supported */
 #if 0 /*(__MPU_PRESENT == 1)*/
 #include "../portable/GCC/ARM_CM4_MPU/port.c"
@@ -31,11 +31,16 @@
 #endif
 #endif
 
-#if (__CORTEX_M == 0x07U)
+#if (__CORTEX_M == 7U)
 /* MPU not supported */
 #if 0 /*(__MPU_PRESENT == 1)*/
 #include "../portable/GCC/ARM_CM7_MPU/r0p1/port.c"
 #else
 #include "../portable/GCC/ARM_CM7/r0p1/port.c"
 #endif
+#endif
+
+#if (__CORTEX_M == 33U)
+/* TZ = 0 */
+#include "../portable/GCC/ARM_CM33_NTZ/non_secure/port.c"
 #endif

--- a/src/portasm.c
+++ b/src/portasm.c
@@ -1,0 +1,15 @@
+/*
+ * @file    portasm.c
+ * @author  Frederic Pillon <frederic.pillon@st.com> for STMicroelectronics.
+ * @brief   Include source of FreeRTOS portable layer file to match Arduino library format
+ */
+#include <Arduino.h>
+
+#ifndef __CORTEX_M
+#pragma GCC error  "no \"__CORTEX_M\" definition"
+#endif
+
+#if (__CORTEX_M == 33U)
+/* TZ = 0 */
+#include "../portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c"
+#endif

--- a/src/portasm.h
+++ b/src/portasm.h
@@ -1,0 +1,20 @@
+/*
+ * @file    portasm.h
+ * @author  Frederic Pillon <frederic.pillon@st.com> for STMicroelectronics.
+ * @brief   Include header of FreeRTOS portable layer file to match Arduino library format
+ */
+
+#ifndef _PORTASM_H_
+#define _PORTASM_H_
+#include "stm32_def.h"
+
+#ifndef __CORTEX_M
+#pragma GCC error  "no \"__CORTEX_M\" definition"
+#endif
+
+#if (__CORTEX_M == 33U)
+/* TZ = 0 */
+#include "../portable/GCC/ARM_CM33_NTZ/non_secure/portasm.h"
+#endif
+
+#endif //_PORTASM_H_

--- a/src/portmacro.h
+++ b/src/portmacro.h
@@ -12,13 +12,13 @@
 #pragma GCC error  "no \"__CORTEX_M\" definition"
 #endif
 
-#if (__CORTEX_M == 0x00U)
+#if (__CORTEX_M == 0U)
 #include "../portable/GCC/ARM_CM0/portmacro.h"
 /* Stub for heap_useNewlib_ST */
 inline __attribute__(( always_inline )) static BaseType_t xPortIsInsideInterrupt( void ) { return pdFALSE; }
 #endif
 
-#if (__CORTEX_M == 0x03U)
+#if (__CORTEX_M == 3U)
 /* MPU not supported */
 #if 0 /*(__MPU_PRESENT == 1)*/
 #include "../portable/GCC/ARM_CM3_MPU/portmacro.h"
@@ -27,7 +27,7 @@ inline __attribute__(( always_inline )) static BaseType_t xPortIsInsideInterrupt
 #endif
 #endif
 
-#if (__CORTEX_M == 0x04U)
+#if (__CORTEX_M == 4U)
 /* MPU not supported */
 #if 0 /*(__MPU_PRESENT == 1)*/
 #include "../portable/GCC/ARM_CM4_MPU/portmacro.h"
@@ -36,13 +36,17 @@ inline __attribute__(( always_inline )) static BaseType_t xPortIsInsideInterrupt
 #endif
 #endif
 
-#if (__CORTEX_M == 0x07U)
+#if (__CORTEX_M == 7U)
 /* MPU not supported */
 #if 0 /*(__MPU_PRESENT == 1)*/
 #include "../portable/GCC/ARM_CM7_MPU/r0p1/portmacro.h"
 #else
 #include "../portable/GCC/ARM_CM7/r0p1/portmacro.h"
 #endif
+#endif
+
+#if (__CORTEX_M == 33U)
+#include "../portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h"
 #endif
 
 #endif //_PORTMACRO_H_


### PR DESCRIPTION
* Update to Freertos 10.3.1
* Add CortexM33 support
* Fix frLiuLayland test on CM0 and CM0+

### STM32FreeRTOS v10.3.1
| Board | AnalogRead_DigitalRead | frBlinkPrint | frLiuLayland | frBlink (CMSIS-RTOSv2) | Blinky (CMSIS-RTOSv2) |
| --- | :---: | :---: | :---: | :---: | :---: |
| [Nucleo F091RC (Cortex-M0)](http://www.st.com/en/evaluation-tools/nucleo-f091rc.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
| [Nucleo G071RB (Cortex-M0+)](http://www.st.com/en/evaluation-tools/nucleo-g071rb.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
| [Nucleo F103RB (Cortex-M3)](http://www.st.com/en/evaluation-tools/nucleo-f103rb.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
| [Nucleo L476RG (Cortex-M4)](http://www.st.com/en/evaluation-tools/nucleo-l476rg.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
| [Nucleo H743ZI (Cortex-M7)](https://www.st.com/en/evaluation-tools/nucleo-h743zi.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
| [Nucleo L552ZE-Q (Cortex-M33)](https://www.st.com/en/evaluation-tools/nucleo-l552ze-q.html) | PASSED | PASSED | PASSED | PASSED | PASSED |
| [Nucleo U575ZI-Q (Cortex-M33)](https://www.st.com/en/evaluation-tools/nucleo-u575zi-q.html) | PASSED | PASSED | PASSED | PASSED | PASSED |