### PR TITLE
feat: provide default functions only if requested

### DIFF
--- a/src/FreeRTOSConfig_Default.h
+++ b/src/FreeRTOSConfig_Default.h
@@ -46,7 +46,16 @@
  * -1 for heap_useNewlib_ST.c
  * Default -1 see heap.c
  */
-/*#define configMEMMANG_HEAP_NB             3*/
+/* #define configMEMMANG_HEAP_NB             3 */
+
+/* Set to 1 to use default blink hook if configUSE_MALLOC_FAILED_HOOK is 1 */
+#ifndef configUSE_MALLOC_FAILED_HOOK_BLINK
+  #define configUSE_MALLOC_FAILED_HOOK_BLINK  0
+#endif
+/* Set to 1 to used default blink if configCHECK_FOR_STACK_OVERFLOW is 1 or 2 */
+#ifndef configCHECK_FOR_STACK_OVERFLOW_BLINK
+  #define configCHECK_FOR_STACK_OVERFLOW_BLINK 0
+#endif
 
 /* configUSE_CMSIS_RTOS_V2 has to be defined and set to 1 to use CMSIS-RTOSv2 */
 /*#define configUSE_CMSIS_RTOS_V2           1*/
@@ -218,7 +227,7 @@ header file. */
 /*
  * IMPORTANT:
  * SysTick_Handler() from stm32duino core is calling weak osSystickHandler().
- * Both CMSIS-RTOSv2 and CMSIS-RTOS override osSystickHandler() 
+ * Both CMSIS-RTOSv2 and CMSIS-RTOS override osSystickHandler()
  * which is calling xPortSysTickHandler(), defined in respective CortexM-x port
  */
 /* #define xPortSysTickHandler SysTick_Handler */

--- a/src/STM32FreeRTOS.c
+++ b/src/STM32FreeRTOS.c
@@ -50,13 +50,12 @@ void assertBlink() {
   errorBlink(1);
 }
 //------------------------------------------------------------------------------
-#if ( configUSE_MALLOC_FAILED_HOOK == 1 )
+#if ( ( configUSE_MALLOC_FAILED_HOOK == 1 ) && ( configUSE_MALLOC_FAILED_HOOK_BLINK == 1 ) )
 	/** vApplicationMallocFailedHook()
-   Blink two short pulses if malloc fails.
-
-	will only be called if
-	configUSE_MALLOC_FAILED_HOOK is set to 1 in FreeRTOSConfig.h.  It is a hook
-	function that will get called if a call to pvPortMalloc() fails.
+  Blink two short pulses if malloc fails. Itwill only be called if
+	configUSE_MALLOC_FAILED_HOOK is set to 1 and
+  configUSE_MALLOC_FAILED_HOOK_BLINK defined in FreeRTOSConfig.h.
+  It is a hook function that will get called if a call to pvPortMalloc() fails.
 	pvPortMalloc() is called internally by the kernel whenever a task, queue,
 	timer or semaphore is created.  It is also called by various parts of the
 	demo application.  If heap_1.c or heap_2.c are used, then the size of the
@@ -87,11 +86,12 @@ void  __attribute__((weak)) vApplicationIdleHook( void ) {
 #endif /* configUSE_IDLE_HOOK == 1 */
 
 /*-----------------------------------------------------------*/
-#if ( configCHECK_FOR_STACK_OVERFLOW >= 1 )
+#if ( ( configCHECK_FOR_STACK_OVERFLOW >= 1 ) && ( configCHECK_FOR_STACK_OVERFLOW_BLINK == 1 ) )
 	/**  Blink three short pulses if stack overflow is detected.
 	Run time stack overflow checking is performed if
-	configCHECK_FOR_STACK_OVERFLOW is defined to 1 or 2.  This hook
-	function is called if a stack overflow is detected.
+	configCHECK_FOR_STACK_OVERFLOW is defined to 1 or 2 and
+  configCHECK_FOR_STACK_OVERFLOW_BLINK is defined.
+  This hook	function is called if a stack overflow is detected.
   \param[in] pxTask Task handle
   \param[in] pcTaskName Task name
   */


### PR DESCRIPTION
`configUSE_MALLOC_FAILED_HOOK` and `configCHECK_FOR_STACK_OVERFLOW` allow to define specific function to call when a malloc failed or a stack overflow occured.
Respectively, `vApplicationIdleHook` and `vApplicationStackOverflowHook`.

Previous implementation provide them unconditionally preventing users to define their own implementation. Now extra config is required to have the default implementation:

```
/* Set to 1 to use default blink hook if configUSE_MALLOC_FAILED_HOOK is 1 */ #ifndef configUSE_MALLOC_FAILED_HOOK_BLINK
  #define configUSE_MALLOC_FAILED_HOOK_BLINK  0
#endif
/* Set to 1 to used default blink if configCHECK_FOR_STACK_OVERFLOW is 1 or 2 */ #ifndef configCHECK_FOR_STACK_OVERFLOW_BLINK
  #define configCHECK_FOR_STACK_OVERFLOW_BLINK 0
#endif
```


Fixes #69.

